### PR TITLE
Apply XxxId convention to anonymous-type properties on read

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -224,7 +224,7 @@ Most declarations don't need an explicit `[Id("...")]` — the analyzer infers a
 
 - **Parameters named exactly `id`** — rule 1 doesn't apply to parameters (a bare `id` has no containing-type equivalent, and parameters should be name-driven so method signatures read cleanly). Write `orderId`, or add `[Id("Order")]` explicitly.
 - **Names that are exactly `Id`** (on parameters) or shorter than 3 characters under rule 2 — so a property literally named `Id` only matches rule 1, never rule 2.
-- **Anonymous-type properties** — `new { CustomerId = x }`. They can't carry `[Id]`, so tagging them would produce diagnostics the user has no way to silence (matters for EF `HasIndex`, LINQ projections, etc.).
+- **Anonymous-type properties under rule 1** — a bare `Id` on `new { Id = x }` would map to a synthesized `<>f__AnonymousType*` name, which is meaningless as a tag. Rule 2 still applies (`new { CustomerId = x }` reads as `"Customer"`), so values projected through anonymous types in LINQ pipelines or EF `HasIndex` expressions keep flowing the right tag downstream. Writes **into** anonymous-type properties never produce a diagnostic — there's no fix site, since anon members can't carry `[Id]`.
 - **Indexers** — `this[Guid id]` never participates.
 - **Implicitly-declared fields** — backing fields, primary-constructor capture fields, and similar compiler-synthesized members.
 - **Members declared in referenced metadata** — BCL and third-party members (`Diagnostic.Id`, `EventArgs`, …) never receive convention tags. If it were otherwise, any library property named `Id` would suddenly carry a tag the user can't change.

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -2553,8 +2553,11 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
-    public async Task AnonymousType_PropertyConvention_IsSkipped()
+    public async Task AnonymousType_WriteIntoAnonProperty_IsSilent()
     {
+        // Writes into anon-type properties have no fix site (anon members can't carry
+        // [Id]) — the convention tag on the anon target is suppressed at report time so
+        // the `BillId` ↔ `ProgramBillBase` mismatch produces no diagnostic.
         var source =
             """
             using System;
@@ -2571,6 +2574,61 @@ public class IdMismatchAnalyzerTests
         var diagnostics = await GetDiagnostics(source);
 
         await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AnonymousType_ReadFromAnonProperty_FlowsConventionTag()
+    {
+        // Reading `extract.CustomerId` from an anonymous type carries the "Customer"
+        // convention tag, so the assignment into a `[Id("Customer")]` target is allowed.
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                [Id("Customer")]
+                public Guid Value { get; set; }
+
+                public void Build(Guid raw)
+                {
+                    var anon = new { CustomerId = raw };
+                    Value = anon.CustomerId;
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AnonymousType_ReadFromAnonProperty_MismatchedTagFires()
+    {
+        // The convention tag on the anon-property source ("Order") doesn't match the
+        // [Id("Customer")] target — SIA001 fires as it would for any mismatched flow.
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                [Id("Customer")]
+                public Guid Value { get; set; }
+
+                public void Build(Guid raw)
+                {
+                    var anon = new { OrderId = raw };
+                    Value = anon.OrderId;
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
     }
 
     [Test]

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -307,17 +307,21 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
                     return false;
                 }
 
-                // Anonymous-type properties can't carry [Id] attributes, and a convention
-                // tag on one would produce SIA001/002/003 reports the user has no way to
-                // silence. Treat them as untagged so values can flow through `new { ... }`
-                // shapes (EF `HasIndex`, LINQ projections) without noise.
-                if (property.ContainingType is { IsAnonymousType: true })
-                {
-                    return false;
-                }
-
                 name = property.Name;
                 containingType = property.ContainingType;
+
+                // Anonymous-type properties can't carry [Id]. The `Id` rule (containing-type
+                // name) on an anon type would map to the synthesized `<>f__AnonymousType*`
+                // name, which is meaningless as a tag — disable it. The `XxxId` rule is
+                // purely name-based, so it still applies and lets values read OUT of an anon
+                // property carry their conventional tag (e.g. `extract.CustomerId` flowing
+                // into a `[Id("Customer")]` target). Writes INTO anon properties are
+                // separately silenced in Report — no fix site exists on the anon side.
+                if (containingType is { IsAnonymousType: true })
+                {
+                    allowIdRule = false;
+                }
+
                 break;
             case IFieldSymbol field:
                 if (field.IsImplicitlyDeclared)
@@ -882,6 +886,13 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         // [Id] so firing here would just be noise.
         if (untaggedSymbol is null ||
             untaggedSymbol.DeclaringSyntaxReferences.IsEmpty)
+        {
+            return;
+        }
+
+        // Anonymous-type members can't carry [Id]; suppress for the same reason as the
+        // target-side check in Report.
+        if (untaggedSymbol is IPropertySymbol { ContainingType.IsAnonymousType: true })
         {
             return;
         }
@@ -2116,6 +2127,16 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         IdInfo target,
         Config config)
     {
+        // Anonymous-type properties can't carry [Id], so any diagnostic against one as a
+        // target has no fix site (covers SIA001/SIA002/SIA003 from a `new { X = expr }`
+        // initializer's synthesized assignment, and any other write where the target lives
+        // on an anonymous type). Reads from anon properties still carry their convention
+        // tag — see TryGetConventionName.
+        if (targetSymbol is IPropertySymbol { ContainingType.IsAnonymousType: true })
+        {
+            return;
+        }
+
         if (source.State == IdState.Unknown ||
             target.State == IdState.Unknown)
         {
@@ -2214,14 +2235,10 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
 
     static bool IsBoundaryTarget(ISymbol target)
     {
-        // Anonymous-type members can't carry [Id], so flowing a tagged value into one
-        // (e.g. `new { BillId = order.BillId }` in an EF `HasIndex` expression) has no
-        // fix site. Treat as boundary so SIA003 stays quiet.
-        if (target is IPropertySymbol { ContainingType.IsAnonymousType: true })
-        {
-            return true;
-        }
-
+        // Anonymous-type members are filtered out earlier in Report, so they can't reach
+        // here. The remaining checks cover targets whose declared type can't meaningfully
+        // hold a tag.
+        //
         // For parameters on a generic method, `.Type` is already substituted at the call
         // site (T → Guid). Inspect the original definition so the type-parameter check
         // actually catches `T`. Properties/fields don't have this issue since their


### PR DESCRIPTION
  Anon-type properties were treated as fully untagged to avoid unfixable diagnostics on writes into new { X = ... }.
  That also silenced the convention on reads, so extract.CustomerId flowing into a [Id("Customer")] target triggered
  SIA002 even though the name clearly matched.

  Now rule 2 applies to anon-type properties (rule 1 still skipped — it would map to the synthesized <>f__AnonymousType*
   name). Writes into anon targets stay silent via a single early-return in Report / ReportMissingOnBinarySide.