### PR TITLE
suppress SIA002 when source param matches target property by name

### DIFF
--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -2775,6 +2775,112 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
+    public async Task ParamMatchingPropertyName_PrimaryCtor_IsSilent()
+    {
+        // The primary-ctor parameter `id` is the obvious carrier for the same-named
+        // tagged property `Id`. Requiring an explicit [Id("Tenant")] on the parameter
+        // would be noise — the user has already expressed intent via the name match.
+        var source =
+            """
+            using System;
+
+            public class Tenant(string id)
+            {
+                public string Id { get; } = id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ParamMatchingPropertyName_RegularCtor_IsSilent()
+    {
+        var source =
+            """
+            using System;
+
+            public class Tenant
+            {
+                public Tenant(string id) => Id = id;
+                public string Id { get; }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ParamMatchingPropertyName_MethodSetter_IsSilent()
+    {
+        // Same name-correspondence rule applies outside constructors: a method param
+        // `id` writing to property `Id` is just as obviously the carrier as in a ctor.
+        var source =
+            """
+            using System;
+
+            public class Order
+            {
+                public string Id { get; set; } = "";
+                public void Reset(string id) => Id = id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ParamMatchingPropertyName_NameMismatch_StillFires()
+    {
+        // Parameter name doesn't correspond to the property name — the suppression
+        // doesn't apply, so SIA002 fires as before. The fix is to rename the parameter
+        // (auto-tag via convention) or add [Id("Customer")] explicitly.
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                public void Update(string raw) => Value = raw;
+                [Id("Customer")] public string Value { get; set; } = "";
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA002");
+    }
+
+    [Test]
+    public async Task ParamMatchingPropertyName_ExplicitTagMismatch_StillFiresSIA001()
+    {
+        // Even with names corresponding, an explicit tag on the parameter that
+        // disagrees with the property's tag goes through SIA001 (mismatch), which the
+        // suppression does NOT silence — source is tagged, not untagged.
+        var source =
+            """
+            using System;
+
+            public class Holder([Id("Customer")] string id)
+            {
+                [Id("Order")] public string Id { get; } = id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+    }
+
+    [Test]
     public async Task AnonymousType_WriteIntoAnonProperty_IsSilent()
     {
         // Writes into anon-type properties have no fix site (anon members can't carry

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -2308,6 +2308,24 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
+            // Param-name ↔ property-name correspondence: a parameter whose name maps
+            // (first-char-upper) to the target property's name is the obvious carrier
+            // for that property's value. The user has already expressed the binding
+            // through naming — requiring an extra `[Id("X")]` on the parameter would be
+            // noise. Covers primary-ctor `Tenant(string id) { Id { get; } = id; }`,
+            // regular-ctor `Tenant(string id) => Id = id;`, and trivial setters
+            // `void Reset(string id) => Id = id;` uniformly.
+            //
+            // Tag mismatches via an explicit attribute on the parameter aren't silenced
+            // here — those flow through the SIA001 branch above (source is Present),
+            // not this one (source is NotPresent).
+            if (sourceSymbol is IParameterSymbol parameter &&
+                targetSymbol is IPropertySymbol property &&
+                ParameterNameCorrespondsToProperty(parameter.Name, property.Name))
+            {
+                return;
+            }
+
             // Fix site is the source symbol's declaration (add Id matching target). The
             // codefix splits the pipe-delimited tags and offers one fix per option plus a
             // combined [UnionId(...)] when the target is multi-tag.
@@ -2353,6 +2371,33 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
                 targetSymbol,
                 source));
         }
+    }
+
+    // Parameters are camelCase, properties PascalCase — so `id` ↔ `Id` and
+    // `customerId` ↔ `CustomerId` should match. Compare ordinal after upper-casing
+    // the parameter's first character, matching the same casing rule already used
+    // by convention rule 2.
+    static bool ParameterNameCorrespondsToProperty(string parameterName, string propertyName)
+    {
+        if (parameterName.Length == 0 || parameterName.Length != propertyName.Length)
+        {
+            return false;
+        }
+
+        if (char.ToUpperInvariant(parameterName[0]) != propertyName[0])
+        {
+            return false;
+        }
+
+        for (var i = 1; i < parameterName.Length; i++)
+        {
+            if (parameterName[i] != propertyName[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     static bool IsBoundaryTarget(ISymbol target)


### PR DESCRIPTION
  Tenant(string id) { public string Id { get; } = id; } and equivalents (regular ctors, simple setters) were firing
  SIA002 because the parameter id carries no convention tag while the property Id does. The user has already expressed
  the binding through naming — requiring an extra [Id("Tenant")] on the parameter is noise.

  Skip SIA002 when the source is a parameter whose name corresponds (first-char-upper) to the target property's name.
  Explicit tag mismatches still go through SIA001 (source is Present in that case).