### PR TITLE
Offer rename-to-convention as a second fix for SIA002/SIA003

### DIFF
--- a/src/StrongIdAnalyzer.CodeFixes/AddIdCodeFixProvider.cs
+++ b/src/StrongIdAnalyzer.CodeFixes/AddIdCodeFixProvider.cs
@@ -389,6 +389,24 @@ public class AddIdCodeFixProvider : CodeFixProvider
                     equivalenceKey: $"AddId:{singleValue}"),
                 diagnostic);
         }
+
+        // For a single-tag diagnostic, renaming the host to `<Tag>Id` satisfies the
+        // naming convention without introducing an attribute. Skipped for UnionId
+        // sources (values.Length > 1) since convention produces exactly one tag.
+        if (values.Length == 1 &&
+            AttributeHost.TryGetRenameTarget(host, values[0], out var newName))
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Rename {hostDescription} to '{newName}'",
+                    cancel => RenameAsync(
+                        context.Document,
+                        declarationLocation,
+                        newName,
+                        cancel),
+                    equivalenceKey: $"RenameId:{newName}"),
+                diagnostic);
+        }
     }
 
     static async Task RegisterReplaceUnionWithIdFix(CodeFixContext context, Diagnostic diagnostic)

--- a/src/StrongIdAnalyzer.CodeFixes/AttributeHost.cs
+++ b/src/StrongIdAnalyzer.CodeFixes/AttributeHost.cs
@@ -86,13 +86,16 @@ static class AttributeHost
             _ => name.ToString()
         };
 
-    // Rename heuristic: if the host name ends with "Id" (e.g. `bidId`, `BidId`), produce
-    // `<tag>Id` with the first character matching the original's case. Skips when the
-    // host is named just "Id" — fixing that would require renaming the containing type.
+    // Rename heuristic: produce `<tag>Id`, matching the first-character case of the
+    // current identifier (camelCase for parameters like `id`, PascalCase for a property
+    // like `Value`). Skips property/field named exactly "Id" — its convention tag is
+    // the containing type's name, so `<tag>Id` would require moving the declaration
+    // to a different type. Parameters named `id` are fine to rename since they have
+    // no containing-type convention.
     public static bool TryGetRenameTarget(SyntaxNode host, string tag, out string newName)
     {
         newName = "";
-        if (tag.Length == 0)
+        if (tag.Length == 0 || !SyntaxFacts.IsValidIdentifier(tag))
         {
             return false;
         }
@@ -111,8 +114,8 @@ static class AttributeHost
             return false;
         }
 
-        if (currentName.Length <= 2 ||
-            !currentName.EndsWith("Id", StringComparison.Ordinal))
+        if (host is not ParameterSyntax &&
+            string.Equals(currentName, "Id", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }

--- a/src/StrongIdAnalyzer.Tests/AddIdCodeFixProviderTests.cs
+++ b/src/StrongIdAnalyzer.Tests/AddIdCodeFixProviderTests.cs
@@ -61,7 +61,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source);
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Add");
 
         await Contains(fixedSource, "[Id(\"Order\")]");
         await Contains(fixedSource, "public Guid Value { get; set; }");
@@ -84,7 +84,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source);
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Add");
 
         await Contains(fixedSource, "[Id(\"Order\")]");
         await Contains(fixedSource, "public Guid Field;");
@@ -105,7 +105,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source);
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Add");
 
         await Contains(fixedSource, "[Id<Order>] Guid input");
     }
@@ -130,7 +130,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source);
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA003", "Add");
 
         await Contains(fixedSource, "[Id<Order>] Guid value");
     }
@@ -155,7 +155,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source);
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA003", "Add");
 
         await Contains(fixedSource, "[Id<Order>]");
         await Contains(fixedSource, "public Guid Value { get; set; }");
@@ -178,7 +178,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source);
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Add");
 
         await Contains(fixedSource, "[Id<Order>]");
         await Contains(fixedSource, "public Guid Other { get; set; }");
@@ -204,6 +204,112 @@ public class AddIdCodeFixProviderTests
         var fixedSource = await ApplyFix(source);
 
         await Contains(fixedSource, "[Id(\"custom-tag\")]");
+    }
+
+    [Test]
+    public async Task SIA002_RenamesSourceParameterToConventionName()
+    {
+        var source =
+            """
+            using System;
+
+            public class Customer
+            {
+                [Id("Customer")]
+                public Guid Id { get; set; }
+            }
+
+            public static class Extensions
+            {
+                public static bool Exists(Customer customer, Guid id) => customer.Id == id;
+            }
+            """;
+
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Rename");
+
+        await Contains(fixedSource, "Guid customerId");
+        await DoesNotContain(fixedSource, "Guid id)");
+    }
+
+    [Test]
+    public async Task SIA003_RenamesTargetParameterToConventionName()
+    {
+        var source =
+            """
+            using System;
+
+            public class Target
+            {
+                public static void Consume(Guid value) { }
+            }
+
+            public class Holder
+            {
+                public Guid OrderId { get; set; }
+
+                public void Use() => Target.Consume(OrderId);
+            }
+            """;
+
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA003", "Rename");
+
+        await Contains(fixedSource, "Guid orderId");
+        await DoesNotContain(fixedSource, "Guid value");
+    }
+
+    [Test]
+    public async Task SIA002_NoRenameWhenTagNotValidIdentifier()
+    {
+        // custom-tag can't form a legal identifier, so only the attribute fix is offered.
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                public Guid Value { get; set; }
+
+                public static void Consume([Id("custom-tag")] Guid value) { }
+
+                public void Use() => Consume(Value);
+            }
+            """;
+
+        var titles = (await GetCodeActions(source)).Select(_ => _.Title).ToArray();
+
+        await Assert.That(titles.Any(_ => _.StartsWith("Rename", StringComparison.Ordinal))).IsFalse();
+        await Assert.That(titles.Any(_ => _.StartsWith("Add", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task SIA002_NoRenameForUnionIdSource()
+    {
+        // The source needs a UnionId to match; convention produces exactly one tag,
+        // so no rename alternative is offered.
+        var source =
+            """
+            using System;
+
+            public class Customer;
+            public class Order;
+
+            public class Target
+            {
+                public Guid Subject { get; set; }
+            }
+
+            public class Holder
+            {
+                [UnionId("Customer", "Order")]
+                public Guid Subject { get; set; }
+
+                public Target Create() => new Target { Subject = Subject };
+            }
+            """;
+
+        var titles = (await GetCodeActions(source)).Select(_ => _.Title).ToArray();
+
+        await Assert.That(titles.Any(_ => _.StartsWith("Rename", StringComparison.Ordinal))).IsFalse();
     }
 
     [Test]
@@ -827,7 +933,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source, "SIA002");
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Add");
 
         await Contains(fixedSource, "[Id<Election>]");
         await DoesNotContain(fixedSource, "[Id(\"Election\")]");
@@ -869,8 +975,13 @@ public class AddIdCodeFixProviderTests
             """;
 
         var titles = (await GetCodeActions(source)).Select(_ => _.Title).ToArray();
-        await Assert.That(titles.Length).IsEqualTo(1);
-        await Assert.That(titles[0]).IsEqualTo("Add [Id<User>] to field 'System'");
+        // Two fixes: add the attribute, or rename the field to the convention form.
+        // The convention-derived tag "ModifiedBy" from the interface member is NOT
+        // offered — it's an inference, not a declaration, and suggesting it would
+        // override the deliberate [Id<User>] already on BaseEntity.ModifiedById.
+        await Assert.That(titles.Length).IsEqualTo(2);
+        await Assert.That(titles).Contains("Add [Id<User>] to field 'System'");
+        await Assert.That(titles).Contains("Rename field 'System' to 'UserId'");
     }
 
     [Test]
@@ -963,7 +1074,7 @@ public class AddIdCodeFixProviderTests
             }
             """;
 
-        var fixedSource = await ApplyFix(source, "SIA002");
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA002", "Add");
 
         await Contains(fixedSource, "[Id(\"NotATypeInScope\")]");
         await DoesNotContain(fixedSource, "[Id<NotATypeInScope>]");


### PR DESCRIPTION
  AddIdCodeFixProvider previously only offered the attribute-add fix for
  untagged sources/targets. It now also proposes renaming the host to
  `<Tag>Id`, which satisfies the naming convention without introducing an
  attribute. The rename alternative is skipped when the tag isn't a valid
  C# identifier, when the host is a property/field already named `Id`
  (its convention tag comes from the containing type), or when the
  diagnostic requires a UnionId (convention produces a single tag).

  TryGetRenameTarget no longer requires the current name to already end
  with `Id`, so parameters like `Guid id` or `Guid value` are now
  renameable to `customerId` / `orderId`.