### PR TITLE
Read suppressed_namespaces via per-tree options, not GlobalOptions

### DIFF
--- a/IntegrationTests/IntegrationTests/.editorconfig
+++ b/IntegrationTests/IntegrationTests/.editorconfig
@@ -1,8 +1,6 @@
-# is_global marks this as a global analyzer config — keys without a section header
-# land in AnalyzerConfigOptionsProvider.GlobalOptions, which is where the analyzer
-# reads `strongidanalyzer.suppressed_namespaces` from.
-is_global = true
+root = true
 
+[*.cs]
 # Defaults (System*, Microsoft*) are replaced wholesale when this key is set —
 # include them alongside the Suppressed* prefix used by
 # SuppressedNamespaceConsumeTests so the rest of the project still compiles clean.

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -86,7 +86,8 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             // identity keeps cross-assembly usage working — e.g. messages assembly tags
             // a property with [Id("Customer")] and the consumer assembly assigns it.
             var suppressedNamespaces = NamespaceSuppression.Read(
-                start.Options.AnalyzerConfigOptionsProvider);
+                start.Options.AnalyzerConfigOptionsProvider,
+                start.Compilation);
             var config = new Config(suppressedNamespaces, start.Compilation);
 
             start.RegisterOperationAction(

--- a/src/StrongIdAnalyzer/NamespaceSuppression.cs
+++ b/src/StrongIdAnalyzer/NamespaceSuppression.cs
@@ -17,9 +17,16 @@ static class NamespaceSuppression
             new(["Microsoft"], true)
         ];
 
-    public static ImmutableArray<NamespacePattern> Read(AnalyzerConfigOptionsProvider options)
+    public static ImmutableArray<NamespacePattern> Read(
+        AnalyzerConfigOptionsProvider options,
+        Compilation compilation)
     {
-        if (!options.GlobalOptions.TryGetValue(optionKey, out var raw))
+        // Read from any syntax tree's options rather than GlobalOptions — `[*.cs]`
+        // editorconfig entries are per-tree and never surface via GlobalOptions.
+        // The value is project-uniform in practice, so a single tree sample is
+        // sufficient and keeps this a one-time read at CompilationStart.
+        var tree = compilation.SyntaxTrees.FirstOrDefault();
+        if (tree is null || !options.GetOptions(tree).TryGetValue(optionKey, out var raw))
         {
             return Default;
         }


### PR DESCRIPTION
  The readme has always advertised `[*.cs]` as the place to configure
  `strongidanalyzer.suppressed_namespaces`, but the analyzer was reading
  from `AnalyzerConfigOptionsProvider.GlobalOptions` — which only sees
  `.globalconfig` / `is_global = true` entries. Users following the readme
  silently got the defaults. Switch to `GetOptions(firstTree)` at
  CompilationStart; one lookup per compilation, same cost, and matches
  what every other Roslyn analyzer does. The integration test's
  `.globalconfig` is replaced by a normal `.editorconfig` to prove the
  documented form now works end-to-end.