### PR TITLE
Skip IdAttribute emission when visible from a referenced assembly

### DIFF
--- a/src/StrongIdAnalyzer.Tests/IdAttributeGeneratorTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdAttributeGeneratorTests.cs
@@ -48,6 +48,44 @@ public class IdAttributeGeneratorTests
         await Assert.That(errors.Length).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task SkipsEmit_WhenAttributeVisibleFromReference()
+    {
+        // Simulate an upstream assembly that already has StrongIdAnalyzer.IdAttribute
+        // exposed (public here stands in for InternalsVisibleTo).
+        var upstreamSource =
+            """
+            namespace StrongIdAnalyzer;
+            using System;
+            public sealed class IdAttribute(string type) : Attribute;
+            """;
+        var upstream = CSharpCompilation.Create(
+            "Upstream",
+            [CSharpSyntaxTree.ParseText(upstreamSource)],
+            TrustedReferences.All,
+            new(OutputKind.DynamicallyLinkedLibrary));
+
+        using var peStream = new MemoryStream();
+        var emitResult = upstream.Emit(peStream);
+        await Assert.That(emitResult.Success).IsTrue();
+        peStream.Position = 0;
+        var upstreamRef = MetadataReference.CreateFromStream(peStream);
+
+        var compilation = CSharpCompilation.Create(
+            "Downstream",
+            [CSharpSyntaxTree.ParseText("public class Dummy {}")],
+            [.. TrustedReferences.All, upstreamRef],
+            new(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(new IdAttributeGenerator());
+        var runResult = driver.RunGenerators(compilation).GetRunResult();
+
+        var generated = runResult.GeneratedTrees
+            .Where(_ => _.FilePath.EndsWith("IdAttribute.g.cs"))
+            .ToArray();
+        await Assert.That(generated.Length).IsEqualTo(0);
+    }
+
     static GeneratorDriverRunResult RunGenerator(string source)
     {
         var compilation = BuildCompilation(source);

--- a/src/StrongIdAnalyzer/IdAttributeGenerator.cs
+++ b/src/StrongIdAnalyzer/IdAttributeGenerator.cs
@@ -120,8 +120,39 @@ public class IdAttributeGenerator : IIncrementalGenerator
         var supportsGenericAttributes = context.ParseOptionsProvider.Select((options, _) =>
             options is CSharpParseOptions { LanguageVersion: >= LanguageVersion.CSharp11 });
 
-        context.RegisterSourceOutput(supportsGenericAttributes, (spc, supportsGeneric) =>
+        // If a referenced assembly already exposes StrongIdAnalyzer.IdAttribute to us
+        // (e.g. an upstream project that grants InternalsVisibleTo), skip emitting to
+        // avoid CS0436 type-conflict errors. We must check actual accessibility from
+        // the current compilation's assembly — GetTypesByMetadataName returns types
+        // from referenced assemblies regardless of accessibility, so an internal-without-IVT
+        // match doesn't count.
+        var attributeAlreadyVisible = context.CompilationProvider.Select((compilation, _) =>
         {
+            var types = compilation.GetTypesByMetadataName("StrongIdAnalyzer.IdAttribute");
+            var currentAssembly = compilation.Assembly;
+            foreach (var type in types)
+            {
+                if (SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, currentAssembly))
+                {
+                    continue;
+                }
+                if (compilation.IsSymbolAccessibleWithin(type, currentAssembly))
+                {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        var input = supportsGenericAttributes.Combine(attributeAlreadyVisible);
+
+        context.RegisterSourceOutput(input, (spc, pair) =>
+        {
+            var (supportsGeneric, alreadyVisible) = pair;
+            if (alreadyVisible)
+            {
+                return;
+            }
             var source = supportsGeneric ? baseSource + genericSource : baseSource;
             spc.AddSource("IdAttribute.g.cs", source);
         });


### PR DESCRIPTION
  Prevents CS0436 type-conflict errors when an upstream project grants
  InternalsVisibleTo to a downstream project — both projects would
  otherwise emit their own internal StrongIdAnalyzer.IdAttribute and
  the downstream compilation would see two copies of the type.

  The generator now checks GetTypesByMetadataName plus
  IsSymbolAccessibleWithin so a reachable definition (public, or
  internal with IVT) suppresses local emission, while an unreachable
  internal definition in an unrelated reference still allows emission.
  The analyzer already matches attributes by fully-qualified name, so
  cross-assembly usage keeps working with a single source of truth.