### PR TITLE
 Flow element tags through [IdTag] generic type parameters

### DIFF
--- a/IntegrationTests/IntegrationTests/ConsumeTests.cs
+++ b/IntegrationTests/IntegrationTests/ConsumeTests.cs
@@ -23,6 +23,42 @@ public class ConsumeTests
     [Test]
     public void GeneratedUnionIdAttribute_IsAvailable() =>
         _ = new UnionIdAttribute("Order", "Customer");
+
+    [Test]
+    public void IdTagTypeParameter_FlowsThroughLinqChain()
+    {
+        // Mirrors the CommitmentsDataModel shape: WellKnownId<Operation>.Guids is
+        // implicitly tagged via [IdTag] T, flows through Except and Select, and
+        // binds the lambda param to the substituted tag — no SIA002 at build time.
+        var mapper = new RoleOperationMapper();
+        mapper.Seed();
+    }
+}
+
+public class Operation;
+
+public static class WellKnownId<[IdTag] T>
+{
+    public static IEnumerable<System.Guid> Guids { get; } = [];
+}
+
+public class RoleOperationMapper
+{
+    [Id<Operation>]
+    static System.Guid[] blocked = [];
+
+    public List<Row> Seed() =>
+        WellKnownId<Operation>
+            .Guids
+            .Except(blocked)
+            .Select(_ => new Row { Target = _ })
+            .ToList();
+}
+
+public class Row
+{
+    [Id<Operation>]
+    public System.Guid Target { get; set; }
 }
 
 public class IdSample

--- a/readme.md
+++ b/readme.md
@@ -811,6 +811,45 @@ Lambda-parameter binding applies to any extension method on `IEnumerable<T>` reg
 Element-returning inference (`.First()` and friends) stays closed to the `System.Linq.Enumerable`/`Queryable` allowlist — a third-party method named `First` could have different semantics, and the element-returning category depends on the semantics, not the signature.
 
 
+### Tagging from a generic type parameter
+
+Generic container types — lookup tables, well-known-id registries, per-domain helpers — can declare the Id tag at the type-parameter level via `[IdTag]`. Collection-typed members of such a container pick up the substituted type argument's short name as an implicit element tag at each use site, so LINQ chains and foreach loops bind their element variables to the right tag without a per-member attribute.
+
+<!-- snippet: IdTagTypeParameter -->
+<a id='snippet-IdTagTypeParameter'></a>
+```cs
+public class Operation;
+
+public static class WellKnownId<[IdTag] T>
+{
+    // [IdTag] on the type parameter marks it as an Id tag source. Members of the
+    // containing type implicitly carry the substituted type argument's short name
+    // as an Id tag at every use site — so WellKnownId<Customer>.Guids is treated
+    // as a Customer-tagged collection without a per-member attribute.
+    public static IEnumerable<Guid> Guids { get; } = [];
+}
+
+public class OperationIndex
+{
+    [Id("Operation")]
+    static Guid[] blocked = [];
+
+    [Id("Customer")]
+    public Guid LatestCustomerId { get; set; }
+
+    // SIA001: .Except is element-preserving, so the walk terminates at
+    // WellKnownId<Operation>.Guids whose implicit tag is "Operation". That tag
+    // rides through .First() and collides with the "Customer"-tagged target.
+    public void Copy() =>
+        LatestCustomerId = WellKnownId<Operation>.Guids.Except(blocked).First();
+}
+```
+<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L426-L454' title='Snippet source file'>snippet source</a> | <a href='#snippet-IdTagTypeParameter' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The implicit flow is deliberately scoped to collection elements. Scalar members — method returns, properties, parameters — still need explicit `[Id]` / `[UnionId]`; otherwise a factory like `WellKnownId<T>.MakeGuid(int)` would silently tag every call site, forcing every receiving field and variable onto the attribute to avoid SIA003. Open-generic references (where the type parameter is still unsubstituted, e.g. member accesses from inside `WellKnownId<T>` itself) produce no implicit tag. Multiple `[IdTag]` parameters on the same type contribute a union: a collection declared on `Cross<[IdTag] T1, [IdTag] T2>` carries both tag names. Nested types inherit the outer type's `[IdTag]` parameters.
+
+
 ### What is not supported
 
 Multi-type-parameter containers — `Dictionary<K,V>`, `KeyValuePair<K,V>`, `ILookup<K,V>`, `IGrouping<K,T>`, `ValueTuple<…>` — are deliberately excluded in this release. A bare `[Id("Customer")]` attribute on a `Dictionary<Guid,Guid>` has no unambiguous target (key? value? both?), so the analyzer ignores the attribute on these shapes and produces no diagnostics for reads through them.
@@ -827,7 +866,7 @@ public class CustomerOrderMap
     public Dictionary<Guid, string> OrdersByCustomer { get; set; } = [];
 }
 ```
-<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L426-L437' title='Snippet source file'>snippet source</a> | <a href='#snippet-UnsupportedMultiTCollection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L456-L467' title='Snippet source file'>snippet source</a> | <a href='#snippet-UnsupportedMultiTCollection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Distinct attributes for the key and value positions, plus tuple-field-level tagging, are on the roadmap but will require a dedicated design pass.

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -4026,6 +4026,312 @@ public class IdMismatchAnalyzerTests
         await Assert.That(diagnostics.Length).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task IdTag_OnTypeParameter_TagsCollectionMember()
+    {
+        // `[IdTag]` on T means `WellKnownId<Operation>.Guids` picks up tag "Operation"
+        // at the use site. `.First()` carries the element tag to the target, so an
+        // explicit-tagged target is silent. `Target` intentionally does not match the
+        // Id/XxxId convention so SIA005 (redundant attribute) does not interfere.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Operation;
+
+            public static class WellKnownId<[IdTag] T>
+            {
+                public static IEnumerable<Guid> Guids => null!;
+            }
+
+            public class Holder
+            {
+                [Id<Operation>]
+                public Guid Target { get; set; }
+
+                public void Copy() =>
+                    Target = WellKnownId<Operation>.Guids.First();
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IdTag_FlowsThroughExceptChain()
+    {
+        // Reproduces the CommitmentsDataModel case: the LINQ chain walks back through
+        // Except (element-preserving) to WellKnownId<Operation>.Guids, which picks up
+        // its implicit tag from `[IdTag] T`.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Operation;
+
+            public static class WellKnownId<[IdTag] T>
+            {
+                public static IEnumerable<Guid> Guids => null!;
+            }
+
+            public class Holder
+            {
+                [Id<Operation>]
+                static Guid[] blocked = null!;
+
+                [Id<Operation>]
+                public Guid Target { get; set; }
+
+                public void Copy() =>
+                    Target = WellKnownId<Operation>.Guids.Except(blocked).First();
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IdTag_Mismatch_ReportsSIA001()
+    {
+        // Tag substitution must actually kick in — if the use site is
+        // `WellKnownId<Operation>` but the target is `[Id<Customer>]`, SIA001 fires.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Operation;
+            public class Customer;
+
+            public static class WellKnownId<[IdTag] T>
+            {
+                public static IEnumerable<Guid> Guids => null!;
+            }
+
+            public class Holder
+            {
+                [Id<Customer>]
+                public Guid Target { get; set; }
+
+                public void Copy() =>
+                    Target = WellKnownId<Operation>.Guids.First();
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+    }
+
+    [Test]
+    public async Task IdTag_ScalarMethodReturn_ProducesNoImplicitTag()
+    {
+        // Scalar method returns are out of scope for implicit [IdTag] flow — otherwise
+        // factory methods (`MakeGuid`, `NewX`) inside a tagged generic would force
+        // every caller storing the result into an untagged field to add [Id] too.
+        // A call-site assignment into an unrelated-tag target stays silent.
+        var source =
+            """
+            using System;
+
+            public class Operation;
+            public class Customer;
+
+            public static class WellKnownId<[IdTag] T>
+            {
+                public static Guid MakeGuid(int index) => Guid.Empty;
+            }
+
+            public class Holder
+            {
+                [Id<Customer>]
+                public Guid Target { get; set; }
+
+                public void Copy() => Target = WellKnownId<Operation>.MakeGuid(0);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IdTag_MethodParameter_ProducesNoImplicitTag()
+    {
+        // Parameters of members inside a `[IdTag]`-tagged generic stay untagged. The
+        // caller's tagged argument landing in an untagged target is SIA003 territory —
+        // that's the pre-existing policy and is unchanged by [IdTag].
+        var source =
+            """
+            using System;
+
+            public class Operation;
+            public class Customer;
+
+            public static class WellKnownId<[IdTag] T>
+            {
+                public static string GetName(Guid id) => "";
+            }
+
+            public class Holder
+            {
+                [Id<Customer>]
+                public Guid Source { get; set; }
+
+                public string Use() => WellKnownId<Operation>.GetName(Source);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA003");
+    }
+
+    [Test]
+    public async Task IdTag_OpenGenericSelfReference_ProducesNoTag()
+    {
+        // Inside WellKnownId<T> itself T is still a type parameter — no real tag name
+        // is available, so the analyzer must not infer anything. Cross-assigning the
+        // untagged Guids to an untagged Guid target is silent.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public static class WellKnownId<[IdTag] T>
+            {
+                public static IEnumerable<Guid> Guids => null!;
+
+                public static Guid First() => Guids.First();
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IdTag_MultipleTagParameters_ProducesUnion()
+    {
+        // Two `[IdTag]` type parameters produce a union tag set on the collection
+        // member. `.First()` inherits the set, so assigning to a target tagged with
+        // either one is silent.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Operation;
+            public class Customer;
+            public class Order;
+
+            public static class Cross<[IdTag] T1, [IdTag] T2>
+            {
+                public static IEnumerable<Guid> Values => null!;
+            }
+
+            public class Holder
+            {
+                [Id<Customer>]
+                public Guid Target { get; set; }
+
+                public void Copy() => Target = Cross<Operation, Customer>.Values.First();
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IdTag_NoAttribute_ProducesNoTag()
+    {
+        // Without `[IdTag]`, a plain generic type parameter must NOT leak a tag.
+        // The `.Select(_ => new Holder { Target = _ })` shape forces the lambda param
+        // resolution path: receiver Guids is untagged, so `_` falls back to NotPresent,
+        // and the assignment to `[Id<Operation>] Target` fires SIA002.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Operation;
+
+            public static class WellKnownId<T>
+            {
+                public static IEnumerable<Guid> Guids => null!;
+            }
+
+            public class Holder
+            {
+                [Id<Operation>]
+                public Guid Target { get; set; }
+
+                public void Use() =>
+                    WellKnownId<Operation>.Guids
+                        .Select(_ => new Holder { Target = _ });
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA002");
+    }
+
+    [Test]
+    public async Task IdTag_NestedGeneric_PicksUpOuterTag()
+    {
+        // A non-generic nested type inside Outer<[IdTag] T> inherits T's substitution
+        // via ContainingType walking, so a collection member on Inner picks up the
+        // outer tag. `.First()` carries the element tag to the assignment target.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Operation;
+
+            public static class Outer<[IdTag] T>
+            {
+                public static class Inner
+                {
+                    public static IEnumerable<Guid> Values => null!;
+                }
+            }
+
+            public class Holder
+            {
+                [Id<Operation>]
+                public Guid Target { get; set; }
+
+                public void Copy() => Target = Outer<Operation>.Inner.Values.First();
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
     static Task<ImmutableArray<Diagnostic>> GetCrossAssemblyDiagnostics(
         string messagesSource,
         string consumerSource)

--- a/src/StrongIdAnalyzer.Tests/Samples.cs
+++ b/src/StrongIdAnalyzer.Tests/Samples.cs
@@ -423,6 +423,36 @@ public class PagedReader
 
 #endregion
 
+#region IdTagTypeParameter
+
+public class Operation;
+
+public static class WellKnownId<[IdTag] T>
+{
+    // [IdTag] on the type parameter marks it as an Id tag source. Members of the
+    // containing type implicitly carry the substituted type argument's short name
+    // as an Id tag at every use site — so WellKnownId<Customer>.Guids is treated
+    // as a Customer-tagged collection without a per-member attribute.
+    public static IEnumerable<Guid> Guids { get; } = [];
+}
+
+public class OperationIndex
+{
+    [Id("Operation")]
+    static Guid[] blocked = [];
+
+    [Id("Customer")]
+    public Guid LatestCustomerId { get; set; }
+
+    // SIA001: .Except is element-preserving, so the walk terminates at
+    // WellKnownId<Operation>.Guids whose implicit tag is "Operation". That tag
+    // rides through .First() and collides with the "Customer"-tagged target.
+    public void Copy() =>
+        LatestCustomerId = WellKnownId<Operation>.Guids.Except(blocked).First();
+}
+
+#endregion
+
 #region UnsupportedMultiTCollection
 
 public class CustomerOrderMap

--- a/src/StrongIdAnalyzer/IdAttributeGenerator.cs
+++ b/src/StrongIdAnalyzer/IdAttributeGenerator.cs
@@ -46,6 +46,21 @@ public class IdAttributeGenerator : IIncrementalGenerator
         #pragma warning disable CS9113
         sealed class UnionIdAttribute(params string[] types) : Attribute;
         #pragma warning restore CS9113
+
+        /// <summary>
+        /// Marks a generic type parameter as an Id tag source for collection-typed
+        /// members of the containing type. <c>WellKnownId&lt;Operation&gt;.Guids</c>,
+        /// where <c>Guids</c> is an <c>IEnumerable&lt;Guid&gt;</c>, picks up the element
+        /// tag <c>"Operation"</c> at the use site without a per-member attribute —
+        /// so LINQ chains and foreach loops over it bind their element variables to
+        /// that tag. Scalar members (method returns, properties, parameters) still
+        /// need explicit <see cref="IdAttribute"/> / <see cref="UnionIdAttribute"/>.
+        /// Open-generic references (T still unsubstituted) produce no tag.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.GenericParameter, Inherited = false)]
+        [ExcludeFromCodeCoverage]
+        [DebuggerNonUserCode]
+        sealed class IdTagAttribute : Attribute;
         """;
 
     // Generic variant — equivalent to [Id(nameof(T))] but enforced by the compiler to

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -586,6 +586,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
 
     const string idMetadataName = "IdAttribute";
     const string unionIdMetadataName = "UnionIdAttribute";
+    const string idTagMetadataName = "IdTagAttribute";
     const string indexAttributeMetadataName = "StrongIdIndexAttribute";
 
     // Looks up pre-resolved tags for `symbol` in the containing-assembly index, if one
@@ -778,6 +779,78 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
     static bool IsAnyIdAttribute(AttributeData attribute) =>
         IsAttributeNamed(attribute, idMetadataName) ||
         TryGetGenericIdTag(attribute, out _);
+
+    // Walk the containing-type chain of `symbol` and collect substituted type-argument
+    // short names for every original-definition type parameter marked [IdTag]. The
+    // attribute is opt-in at the type-parameter declaration, so this produces a tag set
+    // only when the author explicitly marked a generic as an Id-tag source.
+    //
+    // Scope: only wired into the collection-element path (GetExplicitCollectionTags) so
+    // `WellKnownId<Customer>.Guids` flows a tag through LINQ chains. Scalar members
+    // (method returns, properties, parameters) still need explicit [Id] / [UnionId] —
+    // otherwise every factory method inside a `[IdTag]`-annotated type would surface
+    // SIA003 against callers storing the result into an untagged field.
+    //
+    // Skipped when the type argument is still a type parameter (open-generic reference
+    // from inside the declaring type itself) or an error type — same guard TryGetGenericIdTag
+    // uses, for the same reason: no real tag name is available yet.
+    static ImmutableArray<string> GetImplicitTagsFromContainingGenerics(ISymbol symbol)
+    {
+        ImmutableArray<string>.Builder? builder = null;
+        HashSet<string>? seen = null;
+        var containing = symbol.ContainingType;
+        while (containing is not null)
+        {
+            var originalParams = containing.OriginalDefinition.TypeParameters;
+            var constructedArgs = containing.TypeArguments;
+            var count = Math.Min(originalParams.Length, constructedArgs.Length);
+            for (var i = 0; i < count; i++)
+            {
+                if (!HasIdTagAttribute(originalParams[i]))
+                {
+                    continue;
+                }
+
+                var arg = constructedArgs[i];
+                if (arg.TypeKind is TypeKind.Error or TypeKind.TypeParameter)
+                {
+                    continue;
+                }
+
+                var name = arg.Name;
+                if (string.IsNullOrEmpty(name))
+                {
+                    continue;
+                }
+
+                seen ??= new(StringComparer.Ordinal);
+                if (!seen.Add(name))
+                {
+                    continue;
+                }
+
+                builder ??= ImmutableArray.CreateBuilder<string>();
+                builder.Add(name);
+            }
+
+            containing = containing.ContainingType;
+        }
+
+        return builder?.ToImmutable() ?? [];
+    }
+
+    static bool HasIdTagAttribute(ITypeParameterSymbol parameter)
+    {
+        foreach (var attribute in parameter.GetAttributes())
+        {
+            if (IsAttributeNamed(attribute, idTagMetadataName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     // Matches `[UnionId<T1, T2, ...>]` (arities 2..5). Each type argument contributes its
     // short name as a tag, mirroring `[UnionId(nameof(T1), nameof(T2), ...)]`.
@@ -1438,6 +1511,12 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             {
                 return inherited;
             }
+        }
+
+        var implicitTags = GetImplicitTagsFromContainingGenerics(symbol);
+        if (!implicitTags.IsDefaultOrEmpty)
+        {
+            return IdInfo.PresentExplicit(implicitTags);
         }
 
         return IdInfo.NotPresent;


### PR DESCRIPTION
  Introduce [IdTag] on a generic type parameter so collection members of
  the containing type pick up the substituted type argument's short name
  as an implicit element tag — `WellKnownId<Customer>.Guids` now flows
  "Customer" through LINQ chains, foreach, and lambda-param binding.

  Scoped to collection-element resolution only. Scalar returns,
  properties, and parameters still need explicit [Id] / [UnionId];
  flowing through them too would force every caller storing a
  WellKnownId<T>.MakeGuid() result into an untagged field to also carry
  the attribute.