### PR TITLE
Offer rename-to-convention fix per tag for multi-tag SIA002/SIA003 so…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Roslyn analyzer that prevents primitive ID values from being crossed between domain types, using an `[Id("...")]` attribute and compile-time mismatch detection.</Description>

--- a/src/StrongIdAnalyzer.CodeFixes/AddIdCodeFixProvider.cs
+++ b/src/StrongIdAnalyzer.CodeFixes/AddIdCodeFixProvider.cs
@@ -390,12 +390,23 @@ public class AddIdCodeFixProvider : CodeFixProvider
                 diagnostic);
         }
 
-        // For a single-tag diagnostic, renaming the host to `<Tag>Id` satisfies the
-        // naming convention without introducing an attribute. Skipped for UnionId
-        // sources (values.Length > 1) since convention produces exactly one tag.
-        if (values.Length == 1 &&
-            AttributeHost.TryGetRenameTarget(host, values[0], out var newName))
+        // Renaming the host to `<Tag>Id` satisfies the naming convention without
+        // introducing an attribute. For multi-tag sources (explicit [UnionId] or
+        // convention inheritance up a type chain), any single tag satisfies the
+        // other side via set containment, so offer one rename per tag.
+        var seenRenames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var singleValue in values)
         {
+            if (!AttributeHost.TryGetRenameTarget(host, singleValue, out var newName))
+            {
+                continue;
+            }
+
+            if (!seenRenames.Add(newName))
+            {
+                continue;
+            }
+
             context.RegisterCodeFix(
                 CodeAction.Create(
                     $"Rename {hostDescription} to '{newName}'",

--- a/src/StrongIdAnalyzer.CodeFixes/GlobalUsings.cs
+++ b/src/StrongIdAnalyzer.CodeFixes/GlobalUsings.cs
@@ -1,3 +1,5 @@
+global using System;
+global using System.Collections.Generic;
 global using System.Collections.Immutable;
 global using System.Composition;
 global using System.Threading.Tasks;

--- a/src/StrongIdAnalyzer.Tests/AddIdCodeFixProviderTests.cs
+++ b/src/StrongIdAnalyzer.Tests/AddIdCodeFixProviderTests.cs
@@ -282,10 +282,11 @@ public class AddIdCodeFixProviderTests
     }
 
     [Test]
-    public async Task SIA002_NoRenameForUnionIdSource()
+    public async Task SIA002_RenameOfferedPerTagForUnionIdSource()
     {
-        // The source needs a UnionId to match; convention produces exactly one tag,
-        // so no rename alternative is offered.
+        // Multi-tag source (explicit [UnionId]): rename to `<Tag>Id` for any single
+        // tag gives a convention-tagged name that intersects the source set via
+        // containment, so offer one rename per tag.
         var source =
             """
             using System;
@@ -309,7 +310,39 @@ public class AddIdCodeFixProviderTests
 
         var titles = (await GetCodeActions(source)).Select(_ => _.Title).ToArray();
 
-        await Assert.That(titles.Any(_ => _.StartsWith("Rename", StringComparison.Ordinal))).IsFalse();
+        await Assert.That(titles).Contains("Rename property 'Subject' to 'CustomerId'");
+        await Assert.That(titles).Contains("Rename property 'Subject' to 'OrderId'");
+    }
+
+    [Test]
+    public async Task SIA002_RenameOfferedForInheritedConventionIdSource()
+    {
+        // Convention inheritance: `_.Id` on a `GoalAccessRule` whose `Id` is inherited
+        // from `AccessRule` produces tags {GoalAccessRule, AccessRule}. The untagged
+        // lambda parameter should get a rename offer per tag.
+        var source =
+            """
+            using System;
+            using System.Linq;
+
+            public class AccessRule
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class GoalAccessRule : AccessRule;
+
+            public class Holder
+            {
+                public bool Check(IQueryable<GoalAccessRule> rules, Guid id) =>
+                    rules.Any(_ => _.Id == id);
+            }
+            """;
+
+        var titles = (await GetCodeActions(source)).Select(_ => _.Title).ToArray();
+
+        await Assert.That(titles).Contains("Rename parameter 'id' to 'goalAccessRuleId'");
+        await Assert.That(titles).Contains("Rename parameter 'id' to 'accessRuleId'");
     }
 
     [Test]


### PR DESCRIPTION
…urces

  Previously the rename code action was gated on `values.Length == 1`, so
  sources with multiple tags (explicit `[UnionId]` or convention inheritance
  up a type chain) only got "Add attribute" fixes. Now one rename action is
  offered per tag, deduped — e.g. `_.Id == id` where `Id` is inherited from
  `AccessRule` onto `GoalAccessRule` offers both "Rename 'id' to
  'goalAccessRuleId'" and "Rename 'id' to 'accessRuleId'".