### PR TITLE
 Suffix inference: count inherited `Id` members when seeding known tags

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>1.2.6</Version>
+    <Version>1.2.7</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Roslyn analyzer that prevents primitive ID values from being crossed between domain types, using an `[Id("...")]` attribute and compile-time mismatch detection.</Description>

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -2729,6 +2729,56 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
+    public async Task SuffixInference_Enabled_WholePrefixWinsOverInnerWord_IdInherited()
+    {
+        // Same shape as the AccessGroup/Group case but `AccessGroup` inherits `Id` from a
+        // base type rather than declaring it directly. Both `Group` and `AccessGroup` must
+        // qualify as known tags (the receiver-walk produces "AccessGroup" at the call site,
+        // so KnownTags has to recognise inherited `Id` members too) — otherwise longest-first
+        // matching falls through to "Group" and wrongly fires SIA001 on AccessGroup sources.
+        var source =
+            """
+            using System;
+
+            public abstract class BaseEntity
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class Group : BaseEntity { }
+
+            public class AccessGroup : BaseEntity { }
+
+            public class AccessRule : BaseEntity
+            {
+                public Guid AccessGroupId { get; set; }
+            }
+
+            public class Holder
+            {
+                public void AssignFromAccessGroup(AccessRule rule, AccessGroup ag) =>
+                    rule.AccessGroupId = ag.Id;
+
+                public void AssignFromGroup(AccessRule rule, Group g) =>
+                    rule.AccessGroupId = g.Id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsWithOptions(
+            source,
+            new Dictionary<string, string>
+            {
+                ["strongidanalyzer.infer_suffix_ids"] = "true"
+            });
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+        var message = diagnostics[0].GetMessage();
+        await Assert.That(message.Contains("Group")).IsTrue();
+        await Assert.That(message.Contains("AccessGroup")).IsTrue();
+    }
+
+    [Test]
     public async Task SuffixInference_Enabled_WholePrefixUnknown_FallsBackToInnerWord()
     {
         // `productOrderId` — `ProductOrder` is NOT a known tag, so the longest-first walk

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -2246,7 +2246,9 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
     // `hashedId` or `rawId` from being picked up.
     // KnownTags powers suffix inference's "is this candidate a real domain?" check.
     // Two contributions qualify a tag as a domain:
-    //   (1) A type with a conventional `Id` member (rule 1 → containing-type name).
+    //   (1) A type that has a conventional `Id` member — declared directly OR inherited
+    //       from a base type (rule 1 walks the receiver's static-type chain, so a derived
+    //       type inheriting `Id` still produces its own name as a tag).
     //   (2) An explicit `[Id]` / `[UnionId]` / `[return: Id]` anywhere in source.
     // The rule-2 `XxxId` convention on properties/fields/parameters is deliberately
     // NOT included: it would create circularity for longest-first inference, where a
@@ -2259,15 +2261,13 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         var builder = ImmutableHashSet.CreateBuilder(StringComparer.Ordinal);
         foreach (var type in EnumerateSourceTypes(compilation.Assembly.GlobalNamespace))
         {
+            if (type.Name.Length > 0 && HasIdMemberInChain(type))
+            {
+                builder.Add(type.Name);
+            }
+
             foreach (var member in type.GetMembers())
             {
-                if (member is IPropertySymbol or IFieldSymbol &&
-                    member.Name == "Id" &&
-                    TryGetConventionName(member, out var conv))
-                {
-                    builder.Add(conv);
-                }
-
                 var explicitInfo = GetIdFromAttributes(member.GetAttributes());
                 if (explicitInfo.State == IdState.Present)
                 {
@@ -2304,6 +2304,27 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         return builder.ToImmutable();
+    }
+
+    static bool HasIdMemberInChain(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.SpecialType == SpecialType.System_Object)
+            {
+                return false;
+            }
+
+            foreach (var member in current.GetMembers("Id"))
+            {
+                if (member is IPropertySymbol { IsIndexer: false } or IFieldSymbol { IsImplicitlyDeclared: false })
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     static IEnumerable<INamedTypeSymbol> EnumerateSourceTypes(INamespaceSymbol ns)


### PR DESCRIPTION
The previous longest-first fix only added a type to KnownTags if it
  declared `Id` directly. Types that inherit `Id` from a base (e.g.
  `AccessGroup : BaseEntity`) were missing — so `AccessGroupId` would
  fall through to the inner word `Group` instead of matching the exact
  whole-prefix `AccessGroup`.

  CollectKnownTags now walks the inheritance chain (stopping at
  System.Object) and adds the type name whenever any ancestor declares
  an `Id` property/field. Mirrors what the receiver-walk already does at
  diagnostic sites.