### PR TITLE
Suffix inference: include referenced types in the known-tag set

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>1.2.7</Version>
+    <Version>1.2.8</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Roslyn analyzer that prevents primitive ID values from being crossed between domain types, using an `[Id("...")]` attribute and compile-time mismatch detection.</Description>

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -2779,6 +2779,60 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
+    public async Task SuffixInference_Enabled_WholePrefixWinsOverInnerWord_TypesInReferencedAssembly()
+    {
+        // Real-world shape from a downstream Seeding-style project: `AccessGroup` and
+        // `Group` (both with `Id` via `BaseEntity`) live in the upstream assembly. The
+        // consumer assembly has explicit `[Id<Group>]` attributes — so its source-only
+        // KnownTags would have `"Group"` but not `"AccessGroup"`. Without walking the
+        // referenced assembly's types, longest-first matching of the consumer's
+        // `accessGroupId` parameter would skip `"AccessGroup"` (looks unknown) and fall
+        // through to `"Group"`, then wrongly fire SIA001 against `AccessGroup` sources.
+        var upstream =
+            """
+            using System;
+
+            namespace Upstream;
+
+            public abstract class BaseEntity
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class Group : BaseEntity { }
+
+            public class AccessGroup : BaseEntity { }
+            """;
+
+        var consumer =
+            """
+            using System;
+            using StrongIdAnalyzer;
+            using Upstream;
+
+            public class Holder
+            {
+                [Id<Group>]
+                public static readonly Guid SomeGroupId = Guid.NewGuid();
+
+                public void AddUser(Guid accessGroupId) { }
+
+                public void Trigger(AccessGroup ag) => AddUser(ag.Id);
+            }
+            """;
+
+        var diagnostics = await GetCrossAssemblyDiagnosticsWithOptions(
+            upstream,
+            consumer,
+            new Dictionary<string, string>
+            {
+                ["strongidanalyzer.infer_suffix_ids"] = "true"
+            });
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task SuffixInference_Enabled_WholePrefixUnknown_FallsBackToInnerWord()
     {
         // `productOrderId` — `ProductOrder` is NOT a known tag, so the longest-first walk
@@ -4961,7 +5015,16 @@ public class IdMismatchAnalyzerTests
 
     static Task<ImmutableArray<Diagnostic>> GetCrossAssemblyDiagnostics(
         string messagesSource,
-        string consumerSource)
+        string consumerSource) =>
+        GetCrossAssemblyDiagnosticsWithOptions(
+            messagesSource,
+            consumerSource,
+            new Dictionary<string, string>());
+
+    static Task<ImmutableArray<Diagnostic>> GetCrossAssemblyDiagnosticsWithOptions(
+        string messagesSource,
+        string consumerSource,
+        IDictionary<string, string> globalOptions)
     {
         var messagesBase = CSharpCompilation.Create(
             "Messages",
@@ -4993,7 +5056,7 @@ public class IdMismatchAnalyzerTests
 
         var analyzerOptions = new AnalyzerOptions(
             [],
-            new TestAnalyzerConfigOptionsProvider(new Dictionary<string, string>()));
+            new TestAnalyzerConfigOptionsProvider(globalOptions));
 
         return consumerCompilation
             .WithAnalyzers([new IdMismatchAnalyzer()], analyzerOptions)

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -716,7 +716,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         // for the rest of the compilation. Thread-safe via Lazy<T>'s default publication
         // mode.
         public Lazy<ImmutableHashSet<string>> KnownTags { get; } =
-            new(() => CollectKnownTags(compilation));
+            new(() => CollectKnownTags(compilation, suppressedNamespaces));
 
         // Tag-to-ancestor-name cache. Keyed by a tag string; value is the union of base-type
         // and interface names for every type in the compilation whose simple name equals
@@ -2247,25 +2247,37 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
     // KnownTags powers suffix inference's "is this candidate a real domain?" check.
     // Two contributions qualify a tag as a domain:
     //   (1) A type that has a conventional `Id` member — declared directly OR inherited
-    //       from a base type (rule 1 walks the receiver's static-type chain, so a derived
-    //       type inheriting `Id` still produces its own name as a tag).
-    //   (2) An explicit `[Id]` / `[UnionId]` / `[return: Id]` anywhere in source.
+    //       from a base type. The walk uses `compilation.GlobalNamespace` (merged across
+    //       source AND referenced metadata, minus suppressed namespaces), so a project
+    //       referencing a domain assembly that defines `AccessGroup` / `Group` still
+    //       sees them as known tags. Without this, a Seeding project's `accessGroupId`
+    //       parameter would resolve to `"Group"` (an explicit-tag match in source) even
+    //       though `"AccessGroup"` is the right whole-prefix tag, defined upstream.
+    //   (2) An explicit `[Id]` / `[UnionId]` / `[return: Id]` in this compilation's
+    //       source. Cross-assembly explicit attributes already flow through the normal
+    //       analyzer paths; KnownTags only needs the source ones here.
     // The rule-2 `XxxId` convention on properties/fields/parameters is deliberately
     // NOT included: it would create circularity for longest-first inference, where a
     // member like `sourceProductId` would contribute "SourceProduct" to the set and
     // then immediately match itself, defeating the descent to "Product". Domain-ness
     // needs an independent signal — a type or an explicit attribute — not the same
     // member name we're trying to classify.
-    static ImmutableHashSet<string> CollectKnownTags(Compilation compilation)
+    static ImmutableHashSet<string> CollectKnownTags(
+        Compilation compilation,
+        ImmutableArray<NamespacePattern> suppressedNamespaces)
     {
         var builder = ImmutableHashSet.CreateBuilder(StringComparer.Ordinal);
-        foreach (var type in EnumerateSourceTypes(compilation.Assembly.GlobalNamespace))
+
+        foreach (var type in EnumerateAccessibleTypes(compilation.GlobalNamespace, suppressedNamespaces))
         {
             if (type.Name.Length > 0 && HasIdMemberInChain(type))
             {
                 builder.Add(type.Name);
             }
+        }
 
+        foreach (var type in EnumerateSourceTypes(compilation.Assembly.GlobalNamespace))
+        {
             foreach (var member in type.GetMembers())
             {
                 var explicitInfo = GetIdFromAttributes(member.GetAttributes());
@@ -2304,6 +2316,42 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         return builder.ToImmutable();
+    }
+
+    // Walks the merged global namespace (source + references) yielding types whose
+    // containing namespace doesn't match any suppression pattern. The default suppression
+    // set (`System*,Microsoft*`) keeps BCL types out of the walk — without it KnownTags
+    // would balloon and traverse thousands of unrelated framework types per compilation.
+    static IEnumerable<INamedTypeSymbol> EnumerateAccessibleTypes(
+        INamespaceSymbol ns,
+        ImmutableArray<NamespacePattern> suppressedNamespaces)
+    {
+        foreach (var member in ns.GetMembers())
+        {
+            switch (member)
+            {
+                case INamedTypeSymbol type:
+                    if (NamespaceSuppression.IsSuppressed(type, suppressedNamespaces))
+                    {
+                        break;
+                    }
+
+                    yield return type;
+                    foreach (var nested in EnumerateNestedTypes(type))
+                    {
+                        yield return nested;
+                    }
+
+                    break;
+                case INamespaceSymbol child:
+                    foreach (var t in EnumerateAccessibleTypes(child, suppressedNamespaces))
+                    {
+                        yield return t;
+                    }
+
+                    break;
+            }
+        }
     }
 
     static bool HasIdMemberInChain(INamedTypeSymbol type)


### PR DESCRIPTION
  CollectKnownTags previously only walked the current assembly's global
  namespace, so types defined in referenced assemblies (a common shape:
  downstream Seeding project referencing an upstream DataModel) didn't
  qualify as known tags. The consumer's local `[Id<Group>]` attributes
  would still register `"Group"`, so longest-first suffix matching of
  `accessGroupId` would skip the (apparently-unknown) whole-prefix
  `"AccessGroup"` and fall through to `"Group"`, wrongly firing SIA001
  against AccessGroup sources.

  Now walks `compilation.GlobalNamespace` (merged across source +
  references) for the type-with-Id contribution, filtered by the existing
  suppressed_namespaces config so BCL types don't bloat the set. The
  explicit-attribute walk stays source-only.