### PR TITLE
SIA003: suppress when target type still contains an open type parameter

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -52,7 +52,7 @@ SIA001/002/003 fire when the source expression is a **property / field / paramet
 
 ### SIA002/003 suppression
 
-SIA003 is suppressed when the target is: library metadata (BCL/third-party), `object`, an unconstrained generic `T`, or in a namespace matching `strongidanalyzer.suppressed_namespaces` (`.editorconfig`, defaults `System*,Microsoft*`). Trailing `*` = prefix match. Empty value disables namespace suppression but keeps the other suppressions. SIA002 is similarly suppressed when the source lives in referenced metadata.
+SIA003 is suppressed when the target is: library metadata (BCL/third-party), `object`, a type that still contains an open type parameter (bare `T`, `List<T>`, `TestEntity<T>`, `Dictionary<Guid,T>`, `T[]`), or in a namespace matching `strongidanalyzer.suppressed_namespaces` (`.editorconfig`, defaults `System*,Microsoft*`). Trailing `*` = prefix match. Empty value disables namespace suppression but keeps the other suppressions. SIA002 is similarly suppressed when the source lives in referenced metadata.
 
 ## Notes
 

--- a/readme.md
+++ b/readme.md
@@ -451,7 +451,7 @@ SIA003 is suppressed when the id can't meaningfully survive:
 
  * **Library metadata targets** — BCL and third-party members (`Dictionary<Guid, T>.this[Guid]`, `Guid.Equals(Guid)`, `object.Equals(object)`). Library authors can't apply `[Id]`.
  * **`object` parameters / properties / fields** — logging, serialization, message buses. The id is erased through `object` anyway.
- * **Unconstrained generic type parameters (`T`)** — identity methods, container helpers. Generics carry no domain intent.
+ * **Unconstrained generic type parameters (`T`), and constructed generics still containing one (`TestEntity<T>`, `List<T>`, `Dictionary<Guid, T>`, `T[]`)** — identity methods, container helpers, generic wrappers. The target can't carry a domain tag while T is unbound, so SIA003 would have no place to land a fix.
  * **Targets in a suppressed namespace** — by default `System*` and `Microsoft*` (see below).
  * **Equality comparisons** — `==` / `!=` operands are symmetric, so only SIA001 / SIA002 apply.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>1.2.8</Version>
+    <Version>1.2.7</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Roslyn analyzer that prevents primitive ID values from being crossed between domain types, using an `[Id("...")]` attribute and compile-time mismatch detection.</Description>

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -1406,6 +1406,113 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
+    public async Task ConstructedGenericWithOpenTypeParameter_DoesNotFireSIA003()
+    {
+        // Generic wrappers like `TestEntity<T>` are container helpers — the parameter
+        // can't carry a meaningful [Id] because T is open at the declaration. A tagged
+        // source flowing into the wrapper-typed parameter must not fire SIA003.
+        var source =
+            """
+            using System;
+
+            public class TestEntity<T> where T : class
+            {
+                public Guid Id { get; }
+            }
+
+            public static class Verifier
+            {
+                public static void Verify<T>(TestEntity<T> entity) where T : class { }
+            }
+
+            public class Dataset { }
+
+            public static class TestData
+            {
+                [Id("Dataset")]
+                public static TestEntity<Dataset> Published { get; } = null!;
+            }
+
+            public class Consumer
+            {
+                public void Use() => Verifier.Verify(TestData.Published);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConstructedGenericArrayWithOpenTypeParameter_DoesNotFireSIA003()
+    {
+        // Same shape, array of T — should also suppress; `T[]` is just another open
+        // container.
+        var source =
+            """
+            using System;
+
+            public static class Helper
+            {
+                public static void Consume<T>(T[] values) { }
+            }
+
+            public class Holder
+            {
+                [Id("Order")]
+                public Guid[] Ids { get; set; } = [];
+
+                public void Use() => Helper.Consume(Ids);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ClosedGenericTarget_StillFiresSIA003()
+    {
+        // Closing the type argument at the declaration (no open T anywhere) means the
+        // user can apply [Id] to the parameter — SIA003 should still fire so the fixer
+        // can offer to add it.
+        var source =
+            """
+            using System;
+
+            public class TestEntity<T> where T : class
+            {
+                public Guid Id { get; }
+            }
+
+            public class Dataset { }
+
+            public static class Verifier
+            {
+                public static void Verify(TestEntity<Dataset> entity) { }
+            }
+
+            public static class TestData
+            {
+                [Id("Dataset")]
+                public static TestEntity<Dataset> Published { get; } = null!;
+            }
+
+            public class Consumer
+            {
+                public void Use() => Verifier.Verify(TestData.Published);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA003");
+    }
+
+    [Test]
     public async Task SuppressedNamespace_DefaultSystem_NoSIA003()
     {
         // User-declared class in a `System.*` namespace lives in source, so the metadata

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -2749,10 +2749,11 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             }
 
             // Skip when the target's declared type can't meaningfully carry a tag —
-            // `object` parameters/props (logging, serialization) and unconstrained
-            // generics (`T`). Adding [Id] to these wouldn't express intent, and the
-            // common case (passing a tagged id into an ILogger-like helper with an
-            // `object` or `T` arg) would otherwise produce constant noise.
+            // `object` parameters/props (logging, serialization) and any shape still
+            // holding an open type parameter (`T`, `List<T>`, `TestEntity<T>`, `T[]`).
+            // Adding [Id] to these wouldn't express intent, and the common case
+            // (passing a tagged id into an ILogger-like helper or a generic wrapper)
+            // would otherwise produce constant noise.
             if (IsBoundaryTarget(targetSymbol))
             {
                 return;
@@ -2802,8 +2803,9 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         //
         // For parameters on a generic method, `.Type` is already substituted at the call
         // site (T → Guid). Inspect the original definition so the type-parameter check
-        // actually catches `T`. Properties/fields don't have this issue since their
-        // declared type is fixed.
+        // actually catches `T`. Properties/fields declared inside a generic type carry
+        // the unsubstituted type parameter on `.Type` directly, so no original-definition
+        // hop is needed for them.
         var type = target switch
         {
             IParameterSymbol parameter => parameter.OriginalDefinition.Type,
@@ -2817,8 +2819,44 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        // A bare `T`, plus any constructed type that still has an open type parameter
+        // anywhere in its type arguments (`TestEntity<T>`, `List<T>`, `Dictionary<Guid,T>`).
+        // The target can't meaningfully carry a domain tag while T is unbound — the user
+        // would have to know in advance every closing T at every call site, which defeats
+        // the purpose of writing a generic helper. `object` is suppressed for the same
+        // reason: it erases identity at the boundary.
         return type.SpecialType == SpecialType.System_Object ||
-               type.TypeKind == TypeKind.TypeParameter;
+               ContainsOpenTypeParameter(type);
+    }
+
+    // Walks the type and any constructed-generic type arguments / element types looking
+    // for an unsubstituted `ITypeParameterSymbol`. Used by `IsBoundaryTarget` to suppress
+    // SIA003 when the target's declared shape still has a type parameter — bare `T`,
+    // `TestEntity<T>`, `List<T>`, `Dictionary<Guid, T>`, `T[]`, etc.
+    static bool ContainsOpenTypeParameter(ITypeSymbol type)
+    {
+        switch (type.TypeKind)
+        {
+            case TypeKind.TypeParameter:
+                return true;
+            case TypeKind.Array:
+                return ContainsOpenTypeParameter(((IArrayTypeSymbol)type).ElementType);
+            case TypeKind.Pointer:
+                return ContainsOpenTypeParameter(((IPointerTypeSymbol)type).PointedAtType);
+        }
+
+        if (type is INamedTypeSymbol named)
+        {
+            foreach (var arg in named.TypeArguments)
+            {
+                if (ContainsOpenTypeParameter(arg))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     static Diagnostic CreateFixableDiagnostic(


### PR DESCRIPTION
SIA003: suppress when target type still contains an open type parameter `IsBoundaryTarget` already silenced bare `T`, but a constructed generic holding a type parameter (`TestEntity<T>`, `List<T>`, `Dictionary<Guid,T>`, `T[]`) slipped through. The user can't apply [Id] to such a parameter because T is unbound at the declaration, so the diagnostic has no landable fix.
Walks named-type type arguments, array element types, and pointers recursively via a new `ContainsOpenTypeParameter` helper. Closed constructions (`TestEntity<Dataset>`) still fire SIA003 as before.