### PR TITLE
flow anonymous-type member tags through foreach and async materializers

### DIFF
--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -5244,6 +5244,170 @@ public class IdMismatchAnalyzerTests
         await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
     }
 
+    [Test]
+    public async Task AnonymousType_ForEachOverAsyncProjectedList_FlowsInitializerTag()
+    {
+        // The EF-projection shape: project into an anonymous type, materialise with
+        // ToListAsync (Task<List<T>> — the Task layer must be transparent to the
+        // element-preserving shape rule), then foreach the result. The loop variable's
+        // declaring syntax is the ForEachStatement, so the anon-member trace goes
+        // loop var → collection expression → local → ToListAsync → Select → `_.Id`,
+        // recovering the "Dataset" tag. The target infers "Dataset" by convention, so
+        // the previously-firing SIA002 is now silent.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+
+            public static class AsyncLinq
+            {
+                public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => Task.FromResult(new List<T>());
+            }
+
+            public class Dataset
+            {
+                public Guid Id { get; set; }
+                public string Title { get; set; } = "";
+            }
+
+            public class Entry
+            {
+                public Guid DatasetId { get; set; }
+            }
+
+            public class Holder
+            {
+                public IQueryable<Dataset> Datasets { get; set; } = null!;
+
+                public async Task Use()
+                {
+                    var rows = await Datasets
+                        .Where(_ => _.Title.Length > 0)
+                        .OrderBy(_ => _.Title)
+                        .Select(_ => new { _.Id, _.Title })
+                        .ToListAsync();
+                    var entries = new List<Entry>();
+                    foreach (var row in rows)
+                    {
+                        entries.Add(new()
+                        {
+                            DatasetId = row.Id,
+                        });
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AnonymousType_ForEachOverAsyncProjectedList_MismatchedTarget_FiresSIA001()
+    {
+        // Same materialised projection, but the loop body assigns the traced "Dataset"
+        // value into a conventional "Order" target. Before the foreach trace this was a
+        // vague SIA002 (source unknown); with the tag recovered it is a real mismatch.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+
+            public static class AsyncLinq
+            {
+                public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => Task.FromResult(new List<T>());
+            }
+
+            public class Dataset
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class Entry
+            {
+                public Guid OrderId { get; set; }
+            }
+
+            public class Holder
+            {
+                public IQueryable<Dataset> Datasets { get; set; } = null!;
+
+                public async Task Use()
+                {
+                    var rows = await Datasets
+                        .Select(_ => new { _.Id })
+                        .ToListAsync();
+                    var entries = new List<Entry>();
+                    foreach (var row in rows)
+                    {
+                        entries.Add(new()
+                        {
+                            OrderId = row.Id,
+                        });
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+    }
+
+    [Test]
+    public async Task AnonymousType_ForEachOverSyncProjectedList_FlowsInitializerTag()
+    {
+        // Sync counterpart — ToList is already on the element-preserving list, so this
+        // isolates the foreach-loop-variable half of the trace from the Task unwrap.
+        var source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Dataset
+            {
+                public Guid Id { get; set; }
+                public string Title { get; set; } = "";
+            }
+
+            public class Entry
+            {
+                public Guid DatasetId { get; set; }
+            }
+
+            public class Holder
+            {
+                public IQueryable<Dataset> Datasets { get; set; } = null!;
+
+                public void Use()
+                {
+                    var rows = Datasets
+                        .Select(_ => new { _.Id, _.Title })
+                        .ToList();
+                    var entries = new List<Entry>();
+                    foreach (var row in rows)
+                    {
+                        entries.Add(new()
+                        {
+                            DatasetId = row.Id,
+                        });
+                    }
+                }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
     static Task<ImmutableArray<Diagnostic>> GetCrossAssemblyDiagnostics(
         string messagesSource,
         string consumerSource) =>

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -1809,6 +1809,9 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
 
     // `var a = <expr>; a.Member` — trace the local to its declaration initializer and
     // resolve the creation from there. Mirrors TryResolveLocalInitializer's syntax walk.
+    // A foreach loop variable (`foreach (var a in <collection>) { a.Member }`) traces
+    // through the collection expression instead — the chain walk descends its
+    // element-preserving / materializing calls to the projecting Select the same way.
     static IAnonymousObjectCreationOperation? FindAnonymousCreationFromLocal(
         ILocalReferenceOperation localRef,
         Config config)
@@ -1819,27 +1822,30 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        if (reference.GetSyntax() is not VariableDeclaratorSyntax
-            {
-                Initializer.Value: { } initializerSyntax
-            })
-        {
-            return null;
-        }
-
         var semanticModel = localRef.SemanticModel;
         if (semanticModel is null)
         {
             return null;
         }
 
-        var initializerOp = semanticModel.GetOperation(initializerSyntax);
-        if (initializerOp is null)
+        var sourceSyntax = reference.GetSyntax() switch
+        {
+            VariableDeclaratorSyntax { Initializer.Value: { } initializer } => initializer,
+            ForEachStatementSyntax forEach => forEach.Expression,
+            _ => null
+        };
+        if (sourceSyntax is null)
         {
             return null;
         }
 
-        return FindAnonymousCreation(initializerOp, config);
+        var sourceOp = semanticModel.GetOperation(sourceSyntax);
+        if (sourceOp is null)
+        {
+            return null;
+        }
+
+        return FindAnonymousCreation(sourceOp, config);
     }
 
     // Walk a LINQ chain backwards to the Select whose selector builds the anonymous type.
@@ -1978,10 +1984,29 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         var inputElement = definition.Parameters[0].Type.TryGetEnumerableElementType();
-        var outputElement = definition.ReturnType.TryGetEnumerableElementType();
+        var outputElement = UnwrapTaskType(definition.ReturnType).TryGetEnumerableElementType();
         return inputElement is not null &&
                outputElement is not null &&
                SymbolEqualityComparer.Default.Equals(inputElement, outputElement);
+    }
+
+    // Async materializers (EF Core's `ToListAsync`, `ToArrayAsync`, ...) return
+    // Task<List<T>> / ValueTask<T[]> — same element as the receiver, one wrapper deeper.
+    // Callers always reach these through an `await` that Unwrap has already peeled from
+    // the operation tree, so for shape purposes the Task layer is transparent.
+    static ITypeSymbol UnwrapTaskType(ITypeSymbol type)
+    {
+        if (type is INamedTypeSymbol
+            {
+                IsGenericType: true,
+                TypeArguments.Length: 1,
+                Name: "Task" or "ValueTask"
+            } task)
+        {
+            return task.TypeArguments[0];
+        }
+
+        return type;
     }
 
     static bool IsSelectCall(IMethodSymbol method) =>


### PR DESCRIPTION
Trace a foreach loop variable to its collection expression when resolving anonymous-type members, and unwrap Task/ValueTask in the element-preserving shape rule so ToListAsync-style chains descend to the projecting Select.