### PR TITLE
strip underscore prefixes from field name checks

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -40,6 +40,8 @@ Two sources of tags on a primitive ID member:
 1. **Explicit** `[Id("x")]` / `[UnionId("x","y")]` on the property/field/parameter (or on a base property / interface member it overrides/implements).
 2. **Naming convention** — a public member named `Id` or `XxxId` infers the tag from the declaring type (`Id` on `Customer` ⇒ `"Customer"`; `CustomerId` ⇒ `"Customer"`).
 
+Field names run through `Extensions.ConventionName` before any name check: leading underscores are stripped and the first remaining character is upper-cased, so `_id` behaves as `Id` and `_customerId` as `CustomerId`. Field-only — properties and parameters keep their name verbatim. Every name check goes through it (`TryGetConventionName`, both `SuffixInference.TryMatch` call sites, the receiver-type walk's `Id` test, and `HasIdMemberInChain`, which is why that one scans members instead of doing a `GetMembers("Id")` lookup). The code fix has its own copy in `AttributeHost.TryGetRenameTarget` — the two projects share no code.
+
 For inherited `Id` members, the effective tag set is the **union** of explicit tags plus convention tags from every type in the receiver's static-type chain between the receiver and the declaring type. Matching uses **set containment**: a single-tag target is satisfied if its tag appears anywhere in the source's set. See the "Inheritance and covariant Id tagging" section of `readme.md` for the four canonical shapes.
 
 Record primary-constructor parameters: `[Id]` on the parameter is bridged onto the synthesized property (the compiler leaves it on the parameter by default). Explicit `[property: Id(...)]` still wins.

--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,23 @@ Most declarations don't need an explicit `[Id("...")]` — the analyzer infers a
 
     The prefix is the whole identifier minus the trailing `Id` — `OldCustomerId` resolves to `"OldCustomer"`, not `"Customer"`.
 
+### Field underscore prefixes
+
+A field's leading underscores are punctuation, not part of its name, so they are stripped before either rule runs. What follows the prefix is camelCase by that same convention, so its first character is upper-cased.
+
+```cs
+public class Customer
+{
+    // id: "Customer" — `_id` reads as `Id` under rule 1
+    Guid _id;
+
+    // id: "Order" — `_orderId` reads as `OrderId` under rule 2
+    Guid _orderId;
+}
+```
+
+This applies to fields only: a leading underscore has no established meaning on a property, and on a parameter it marks a discard. A field with nothing but underscores (`_`) has no name left to match and gets no id.
+
 ### What does *not* get a convention id
 
 - **Parameters named exactly `id`** — rule 1 doesn't apply to parameters (a bare `id` has no containing-type equivalent, and parameters should be name-driven so method signatures read cleanly). Write `orderId`, or add `[Id("Order")]` explicitly.
@@ -389,7 +406,7 @@ For flow-style mismatches (argument, assignment, property/field initializer) the
 
  * **Change attribute on `<kind> '<name>'` to `[Id("<source id>")]`** — when the target already carries an explicit `[Id]` / `[UnionId]`, replaces it with the source's id.
  * **Add `[Id("<source id>")]` to `<kind> '<name>'`** — when the target is untagged (its current id came from naming convention), adds the attribute.
- * **Rename `<kind> '<name>'` to `<sourceTag>Id`** — when the target has no explicit attribute and its name matches the `XxxId` convention. First-character case is preserved (`bidId` → `treasuryBidId`, `BidId` → `TreasuryBidId`). Works for parameters, properties, and single-declarator fields.
+ * **Rename `<kind> '<name>'` to `<sourceTag>Id`** — when the target has no explicit attribute and its name matches the `XxxId` convention. First-character case is preserved (`bidId` → `treasuryBidId`, `BidId` → `TreasuryBidId`), as is a field's underscore prefix (`_bidId` → `_treasuryBidId`). Works for parameters, properties, and single-declarator fields.
 
 The `<source id>` is the receiver's static type, not the declaring type of the `Id` member. For `treasuryBid.Id` where `Id` is inherited from `BaseEntity`, the fix suggests `TreasuryBid` — what reads locally at the call site — rather than `BaseEntity`.
 

--- a/src/StrongIdAnalyzer.CodeFixes/AttributeHost.cs
+++ b/src/StrongIdAnalyzer.CodeFixes/AttributeHost.cs
@@ -88,10 +88,13 @@ static class AttributeHost
 
     // Rename heuristic: produce `<tag>Id`, matching the first-character case of the
     // current identifier (camelCase for parameters like `id`, PascalCase for a property
-    // like `Value`). Skips property/field named exactly "Id" — its convention tag is
-    // the containing type's name, so `<tag>Id` would require moving the declaration
-    // to a different type. Parameters named `id` are fine to rename since they have
-    // no containing-type convention.
+    // like `Value`). A field's underscore prefix is punctuation, not part of the name —
+    // it is carried through untouched and the casing decision is made on what follows it
+    // (`_bidId` → `_treasuryBidId`). Skips property/field named exactly "Id" — its
+    // convention tag is the containing type's name, so `<tag>Id` would require moving the
+    // declaration to a different type; the same holds for its underscore-prefixed field
+    // form (`_id`). Parameters named `id` are fine to rename since they have no
+    // containing-type convention.
     public static bool TryGetRenameTarget(SyntaxNode host, string tag, out string newName)
     {
         newName = "";
@@ -114,17 +117,36 @@ static class AttributeHost
             return false;
         }
 
+        var prefixLength = 0;
+        if (host is FieldDeclarationSyntax)
+        {
+            while (prefixLength < currentName.Length && currentName[prefixLength] == '_')
+            {
+                prefixLength++;
+            }
+
+            // An all-underscore name (`_`) has no body to case-adjust — leave it whole
+            // and let the normal `<tag>Id` rename apply.
+            if (prefixLength == currentName.Length)
+            {
+                prefixLength = 0;
+            }
+        }
+
+        var prefix = currentName.Substring(0, prefixLength);
+        var bareName = currentName.Substring(prefixLength);
+
         if (host is not ParameterSyntax &&
-            string.Equals(currentName, "Id", StringComparison.OrdinalIgnoreCase))
+            string.Equals(bareName, "Id", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        var firstIsLower = char.IsLower(currentName[0]);
+        var firstIsLower = char.IsLower(bareName[0]);
         var adjusted = firstIsLower
             ? char.ToLowerInvariant(tag[0]) + tag.Substring(1)
             : char.ToUpperInvariant(tag[0]) + tag.Substring(1);
-        newName = adjusted + "Id";
+        newName = prefix + adjusted + "Id";
         return newName != currentName;
     }
 }

--- a/src/StrongIdAnalyzer.Tests/AddIdCodeFixProviderTests.cs
+++ b/src/StrongIdAnalyzer.Tests/AddIdCodeFixProviderTests.cs
@@ -526,6 +526,63 @@ public class AddIdCodeFixProviderTests
     }
 
     [Test]
+    public async Task SIA001_RenamesUnderscorePrefixedField()
+    {
+        // The underscore prefix is carried through untouched and the camelCase of the
+        // name after it is preserved: `_bidId` → `_treasuryBidId`.
+        var source =
+            """
+            using System;
+
+            public class Target
+            {
+                public Guid _bidId;
+            }
+
+            public class Bid
+            {
+                [Id("TreasuryBid")]
+                public Guid Id { get; set; }
+
+                public void Use(Target target) => target._bidId = Id;
+            }
+            """;
+
+        var fixedSource = await ApplyFixByTitlePrefix(source, "SIA001", "Rename");
+
+        await Contains(fixedSource, "public Guid _treasuryBidId;");
+        await Contains(fixedSource, "target._treasuryBidId = Id");
+    }
+
+    [Test]
+    public async Task SIA001_NoRenameOfferedForUnderscoreIdField()
+    {
+        // `_id` takes its tag from the containing type, same as `Id` — renaming it to
+        // `<tag>Id` would mean moving the declaration to another type, so no rename.
+        var source =
+            """
+            using System;
+
+            public class Target
+            {
+                public Guid _id;
+            }
+
+            public class Bid
+            {
+                [Id("TreasuryBid")]
+                public Guid Value { get; set; }
+
+                public void Use(Target target) => target._id = Value;
+            }
+            """;
+
+        var titles = (await GetCodeActions(source)).Select(_ => _.Title).ToArray();
+
+        await Assert.That(titles.Any(_ => _.StartsWith("Rename", StringComparison.Ordinal))).IsFalse();
+    }
+
+    [Test]
     public async Task SIA003_RenamesRecordPrimaryCtorIdParameter()
     {
         var source =

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -1899,6 +1899,39 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
+    public async Task Convention_InheritedUnderscoreIdField_CarriesReceiverTag()
+    {
+        // `_id` reads as `Id`, so the covariant receiver-type walk applies to it too:
+        // `child._id` carries {"Base", "Child"} even though the field is declared on Base
+        // and never redeclared. Without the receiver contribution the set is {"Base"}
+        // alone and this call fires SIA001.
+        var source =
+            """
+            using System;
+
+            public class Base
+            {
+                public Guid _id;
+            }
+
+            public class Child : Base
+            {
+            }
+
+            public class Holder
+            {
+                public void Consume([Id("Child")] Guid value) { }
+
+                public void Use(Child child) => Consume(child._id);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Convention_UnderscoreOnlyField_NoConvention()
     {
         // Nothing left after the prefix — no name to match, so no tag (SIA002 rather
@@ -2822,25 +2855,27 @@ public class IdMismatchAnalyzerTests
     [Test]
     public async Task SuffixInference_Enabled_OnUnderscoreField()
     {
-        // Two underscore trims in one shape: `Product._id` reads as `Id`, which is what
-        // makes "Product" a known tag, and `_sourceProductId` descends to that tag.
+        // Two underscore trims in one shape: `Wigwam._id` reads as `Id`, which is what
+        // makes "Wigwam" a known tag, and `_sourceWigwamId` descends to that tag. The
+        // domain name is deliberately one no referenced assembly can also define — a
+        // common name would let a stray library type supply the known tag instead.
         var source =
             """
             using System;
 
-            public class Product
+            public class Wigwam
             {
                 public Guid _id;
             }
 
             public class Slot
             {
-                public Guid _sourceProductId;
+                public Guid _sourceWigwamId;
             }
 
             public class Caller
             {
-                public void Fill(Product product, Slot slot) => slot._sourceProductId = product._id;
+                public void Fill(Wigwam wigwam, Slot slot) => slot._sourceWigwamId = wigwam._id;
             }
             """;
 
@@ -2852,6 +2887,95 @@ public class IdMismatchAnalyzerTests
             });
 
         await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SuffixInference_Enabled_WholePrefixWinsOverInnerWord_OnUnderscoreField()
+    {
+        // The underscore trim is what creates the whole-prefix candidate: `_accessGroupId`
+        // reads as `AccessGroupId`, so "AccessGroup" is tried (and wins) before the inner
+        // word "Group". Untrimmed, `_accessGroup` matches nothing and resolution falls
+        // through to "Group" — which would make this assignment silently clean.
+        var source =
+            """
+            using System;
+
+            public class Group
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class AccessGroup
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class AccessRule
+            {
+                public Guid _accessGroupId;
+            }
+
+            public class Holder
+            {
+                public void AssignFromGroup(AccessRule rule, Group group) =>
+                    rule._accessGroupId = group.Id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsWithOptions(
+            source,
+            new Dictionary<string, string>
+            {
+                ["strongidanalyzer.infer_suffix_ids"] = "true"
+            });
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+        await Assert.That(diagnostics[0].GetMessage()).IsEqualTo(
+            """Value with [Id("Group")] is assigned to a target with [Id("AccessGroup")]""");
+    }
+
+    [Test]
+    public async Task SuffixInference_Enabled_UnderscoreFieldInitializer()
+    {
+        // Same resolution over the field-initializer path, which reaches the tag through
+        // GetIdWithInheritance rather than the member-access walk.
+        var source =
+            """
+            using System;
+
+            public class Group
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class AccessGroup
+            {
+                public Guid Id { get; set; }
+            }
+
+            public class Holder
+            {
+                public static Group Group = new();
+            }
+
+            public class AccessRule
+            {
+                Guid _accessGroupId = Holder.Group.Id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsWithOptions(
+            source,
+            new Dictionary<string, string>
+            {
+                ["strongidanalyzer.infer_suffix_ids"] = "true"
+            });
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+        await Assert.That(diagnostics[0].GetMessage()).IsEqualTo(
+            """Value with [Id("Group")] is assigned to a target with [Id("AccessGroup")]""");
     }
 
     [Test]

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -1797,6 +1797,133 @@ public class IdMismatchAnalyzerTests
     }
 
     [Test]
+    public async Task Convention_UnderscoreField_Applies()
+    {
+        // The underscore prefix a field conventionally carries isn't part of the name,
+        // so `_orderId` reads as `OrderId` — tag "Order".
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                Guid _orderId;
+
+                public void Consume([Id("Customer")] Guid value) { }
+
+                public void Use() => Consume(_orderId);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+        await Assert.That(diagnostics[0].GetMessage().Contains("Order")).IsTrue();
+    }
+
+    [Test]
+    public async Task Convention_UnderscoreField_MatchingTag_NoDiagnostic()
+    {
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                Guid _customerId;
+
+                public void Consume([Id("Customer")] Guid value) { }
+
+                public void Use() => Consume(_customerId);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Convention_DoubleUnderscoreField_Applies()
+    {
+        // Every leading underscore is stripped, not just the first.
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                Guid __orderId;
+
+                public void Consume([Id("Customer")] Guid value) { }
+
+                public void Use() => Consume(__orderId);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+        await Assert.That(diagnostics[0].GetMessage().Contains("Order")).IsTrue();
+    }
+
+    [Test]
+    public async Task Convention_UnderscoreIdField_UsesContainingType()
+    {
+        // `_id` is the underscore-prefixed camelCase form of `Id`, so rule 1 applies and
+        // the tag comes from the containing type.
+        var source =
+            """
+            using System;
+
+            public class Customer
+            {
+                public Guid _id;
+            }
+
+            public class Holder
+            {
+                public void Consume([Id("Order")] Guid value) { }
+
+                public void Use(Customer customer) => Consume(customer._id);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
+        await Assert.That(diagnostics[0].GetMessage().Contains("Customer")).IsTrue();
+    }
+
+    [Test]
+    public async Task Convention_UnderscoreOnlyField_NoConvention()
+    {
+        // Nothing left after the prefix — no name to match, so no tag (SIA002 rather
+        // than SIA001).
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                Guid _;
+
+                public void Consume([Id("Order")] Guid value) { }
+
+                public void Use() => Consume(_);
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo("SIA002");
+    }
+
+    [Test]
     public async Task Convention_NonIdName_NoConvention()
     {
         // "Value" isn't an Id-convention name, so no inferred tag — passing to an [Id]
@@ -2001,6 +2128,28 @@ public class IdMismatchAnalyzerTests
             {
                 [Id("Customer")]
                 public Guid CustomerId { get; set; }
+            }
+            """;
+
+        var diagnostics = await GetDiagnostics(source);
+        var sia005 = diagnostics.Where(_ => _.Id == "SIA005").ToArray();
+
+        await Assert.That(sia005.Length).IsEqualTo(1);
+        await Assert.That(sia005[0].GetMessage().Contains("Customer")).IsTrue();
+    }
+
+    [Test]
+    public async Task SIA005_RedundantAttributeOnUnderscoreField_Fires()
+    {
+        // `_customerId` already infers "Customer", so the explicit attribute is redundant.
+        var source =
+            """
+            using System;
+
+            public class Holder
+            {
+                [Id("Customer")]
+                Guid _customerId;
             }
             """;
 
@@ -2657,6 +2806,41 @@ public class IdMismatchAnalyzerTests
             public class Caller
             {
                 public void Fill(Product p, Slot s) => s.SourceProductId = p.Id;
+            }
+            """;
+
+        var diagnostics = await GetDiagnosticsWithOptions(
+            source,
+            new Dictionary<string, string>
+            {
+                ["strongidanalyzer.infer_suffix_ids"] = "true"
+            });
+
+        await Assert.That(diagnostics.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SuffixInference_Enabled_OnUnderscoreField()
+    {
+        // Two underscore trims in one shape: `Product._id` reads as `Id`, which is what
+        // makes "Product" a known tag, and `_sourceProductId` descends to that tag.
+        var source =
+            """
+            using System;
+
+            public class Product
+            {
+                public Guid _id;
+            }
+
+            public class Slot
+            {
+                public Guid _sourceProductId;
+            }
+
+            public class Caller
+            {
+                public void Fill(Product product, Slot slot) => slot._sourceProductId = product._id;
             }
             """;
 

--- a/src/StrongIdAnalyzer/Extensions.cs
+++ b/src/StrongIdAnalyzer/Extensions.cs
@@ -153,6 +153,43 @@ static class Extensions
         }
     }
 
+    // The name a symbol is matched against by the naming-convention rules. Fields
+    // conventionally carry an underscore prefix (`_id`, `_customerId`, occasionally
+    // `__id`), which is punctuation rather than part of the name, so it is stripped.
+    // What follows the prefix is camelCase by that same convention, so the first
+    // character is upper-cased — `_id` reads as `Id` (the containing-type rule) and
+    // `_customerId` as `CustomerId` (the `XxxId` rule). An all-underscore name (`_`)
+    // has nothing to strip and is returned as-is. Other symbol kinds are returned
+    // unchanged: a leading underscore has no established meaning on a property, and on
+    // a parameter it marks a discard rather than an id.
+    public static string ConventionName(this ISymbol symbol)
+    {
+        var name = symbol.Name;
+        if (symbol is not IFieldSymbol || name.Length == 0 || name[0] != '_')
+        {
+            return name;
+        }
+
+        var start = 1;
+        while (start < name.Length && name[start] == '_')
+        {
+            start++;
+        }
+
+        if (start == name.Length)
+        {
+            return name;
+        }
+
+        var trimmed = name.Substring(start);
+        if (char.IsLower(trimmed[0]))
+        {
+            return char.ToUpperInvariant(trimmed[0]) + trimmed.Substring(1);
+        }
+
+        return trimmed;
+    }
+
     public static bool HasIdMemberInChain(this INamedTypeSymbol type)
     {
         for (var current = type; current is not null; current = current.BaseType)
@@ -162,9 +199,14 @@ static class Extensions
                 return false;
             }
 
-            foreach (var member in current.GetMembers("Id"))
+            // Scans every member rather than looking up "Id" directly: an underscore-
+            // prefixed field (`_id`) reads as `Id` under the convention, so the match has
+            // to run through ConventionName. Roslyn materializes the full member list for
+            // a name lookup anyway, so this costs an iteration, not extra symbol loading.
+            foreach (var member in current.GetMembers())
             {
-                if (member is IPropertySymbol { IsIndexer: false } or IFieldSymbol { IsImplicitlyDeclared: false })
+                if (member is IPropertySymbol { IsIndexer: false } or IFieldSymbol { IsImplicitlyDeclared: false } &&
+                    member.ConventionName() == "Id")
                 {
                     return true;
                 }

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -328,6 +328,9 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
     //   - property/field named "Id"       -> containing type's metadata name (ignoring namespace and parent)
     //   - property/field/parameter named "<Xxx>Id" -> "<Xxx>" (first char uppercased, so
     //     camelCase parameters like `orderId` match the PascalCase tag of `OrderId`)
+    // Field names run through ConventionName first, so the underscore prefix a field
+    // conventionally carries is not part of what either rule sees — `_id` behaves as
+    // `Id`, `_customerId` as `CustomerId`.
     // The `Id` rule does not apply to parameters — a bare `id` has no containing-type
     // equivalent, and this keeps method signatures' inferred tags purely name-driven.
     // `fromContainingType` is true only when the `Id` rule fired; that's the one that can
@@ -373,7 +376,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
                     return false;
                 }
 
-                name = field.Name;
+                name = field.ConventionName();
                 containingType = field.ContainingType;
                 break;
             case IParameterSymbol parameter:
@@ -1617,7 +1620,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             // GetIdWithInheritance for parameter references.
             if (config.InferSuffixTags &&
                 level is IPropertySymbol or IFieldSymbol &&
-                SuffixInference.TryMatch(level.Name, config.KnownTags.Value, out var suffixTag))
+                SuffixInference.TryMatch(level.ConventionName(), config.KnownTags.Value, out var suffixTag))
             {
                 if (seen.Add(suffixTag))
                 {
@@ -1643,7 +1646,8 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         //    Only the `Id` rule applies here; `XxxId` is name-based and already captured.
         //    Stop at System.Object so "Object" never leaks into the tag set — relevant
         //    when the declaring type is an interface and `.BaseType` walks past it.
-        if (member is { Name: "Id", ContainingType: { } memberContaining } &&
+        if (member.ConventionName() == "Id" &&
+            member.ContainingType is { } memberContaining &&
             receiverType is INamedTypeSymbol rt)
         {
             var boundary = memberContaining.OriginalDefinition;
@@ -1750,7 +1754,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             // unchanged for names that don't match a known suffix.
             if (config.InferSuffixTags &&
                 symbol is IPropertySymbol or IFieldSymbol or IParameterSymbol &&
-                SuffixInference.TryMatch(symbol.Name, config.KnownTags.Value, out var suffixTag))
+                SuffixInference.TryMatch(symbol.ConventionName(), config.KnownTags.Value, out var suffixTag))
             {
                 return IdInfo.Present(suffixTag);
             }


### PR DESCRIPTION
A field's leading underscores are punctuation, not part of its name, so they are stripped before any naming-convention rule runs. What follows is camelCase by that same convention, so its first character is upper-cased: `_id` reads as `Id` (containing-type rule) and `_customerId` as `CustomerId` (`XxxId` rule).

Field-only — a leading underscore has no established meaning on a property, and on a parameter it marks a discard.

Applied at every name check: TryGetConventionName, both SuffixInference.TryMatch call sites, the receiver-type walk's `Id` test, and HasIdMemberInChain (which now scans members rather than looking up "Id", so a type whose only id member is `_id` still counts as a domain for KnownTags). The code fix carries the prefix through its rename (`_bidId` -> `_treasuryBidId`) and skips `_id` for the same reason it already skipped `Id`.