### PR TITLE
make diagnostic messages actionable and add per-rule docs

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -29,6 +29,10 @@ Three source projects, all in `src/`:
 
 `IntegrationTests/` is a separate solution with its own `nuget.config` pointing at `../nugets/` to consume the just-built package rather than project references.
 
+### Diagnostic messages and docs
+
+Messages are the only part of a diagnostic that reaches build output, so `Rules.cs` writes them for a reader with nothing else: each names both symbols (`Rules.Describe` — `property 'Order.CustomerId'`, `parameter 'x' of 'Type.Method'`; SIA004 uses the namespace-qualified form because that is the rule where unqualified names collide), spells out the attribute to write (`FormatAttribute`: one tag → `[Id("X")]`, several → `[UnionId("X", "Y")]`, always the *fix* tags, i.e. explicit tags when the tagged side has any), and gives the fix-site location (`Site`: `(line N)` in the same file, `(path:N)` otherwise, nothing for metadata). `MessageTests.cs` pins every rule's exact text — a wording change is a contract change, update it there. Every descriptor carries `helpLinkUri` = `https://github.com/SimonCropp/StrongIdAnalyzer/blob/main/docs/<ID>.md` and a `description`; the Roslyn analyzer-authoring rules (RS1032/RS1033) require messages that end in a period when multi-sentence and descriptions that end in punctuation. `docs/SIA00x.md` is the per-rule page (cause, message anatomy, every fix, suppressions); `readme.md`'s Diagnostics section is only the table plus "Reading a diagnostic", and links there. Snippets in the docs are mdsnippets-managed like the readme.
+
 ### Diagnostic release tracking
 
 `src/StrongIdAnalyzer/AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` are `AdditionalFiles` — Roslyn's release-tracking analyzer will fail the build if a new diagnostic ID is added to `SupportedDiagnostics` without a corresponding entry in `Unshipped.md`.

--- a/docs/SIA001.md
+++ b/docs/SIA001.md
@@ -1,0 +1,75 @@
+# SIA001 — Id mismatch
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Warning  | Yes      | No — two competing fixes, pick one by hand |
+
+Fires when both sides of a flow carry an id and the ids differ. The analyzer sees an unambiguous cross-domain flow (a `Customer` id passed where an `Order` id is expected) and refuses it.
+
+Flows are arguments, assignments, property/field initializers, `return` statements, and `==` / `!=` operands.
+
+
+## Example
+
+<!-- snippet: SIA001Example -->
+<a id='snippet-SIA001Example'></a>
+```cs
+public class SIA001Sample
+{
+    // CustomerId is tagged "Customer" by naming convention.
+    public Guid CustomerId { get; set; }
+
+    public static void ProcessOrder(Guid orderId) { }
+
+    public void Trigger() =>
+        // SIA001: argument tagged [Id("Customer")] passed to parameter tagged [Id("Order")].
+        ProcessOrder(CustomerId);
+}
+```
+<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L123-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-SIA001Example' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Build output:
+
+```
+SIA001: property 'SIA001Sample.CustomerId' is [Id("Customer")] and flows to parameter 'orderId' of 'SIA001Sample.ProcessOrder', which is [Id("Order")]. Fix: apply [Id("Customer")] to parameter 'orderId' of 'SIA001Sample.ProcessOrder' (line 6), or pass a value tagged [Id("Order")].
+```
+
+The message names the source (what is being passed), the target (what receives it), and the declaration line of the target. When the target lives in another file the path is included instead: `(D:\src\OrderService.cs:14)`. Equality checks say `is compared with` instead of `flows to`.
+
+
+## How to fix
+
+There are exactly two possibilities, and the analyzer cannot tell which one applies. Decide first, then edit:
+
+1. **The target's id is wrong.** The parameter really does accept a customer id and was mis-tagged (or mis-named — `orderId` when it should be `customerId`). Change the attribute on the target, or rename it so the naming convention infers the right id. This is what the "Fix:" clause in the message and the IDE code fix both do.
+2. **The wrong value is being passed.** The target is correct and the call site is the bug — a real cross-domain mix-up, which is the whole reason the analyzer exists. Pass the right value.
+
+Do not silence SIA001 with `#pragma warning disable` or by removing the source's attribute. The warning is the analyzer catching precisely the class of bug it is for; both of those hide the bug rather than fixing it.
+
+`[UnionId("A", "B")]` on the target is the answer only when the target genuinely accepts either domain (a generic lookup helper, a cache key). It is not a way to make a mismatch go away.
+
+
+## IDE code fixes
+
+For flow-style mismatches (argument, assignment, property/field initializer) the analyzer attaches the **target** declaration as the fix site and offers:
+
+ * **Change attribute on `<kind> '<name>'` to `[Id("<source id>")]`** — when the target already carries an explicit `[Id]` / `[UnionId]`, replaces it with the source's id.
+ * **Add `[Id("<source id>")]` to `<kind> '<name>'`** — when the target is untagged (its current id came from naming convention), adds the attribute.
+ * **Rename `<kind> '<name>'` to `<sourceTag>Id`** — when the target has no explicit attribute and its name matches the `XxxId` convention. First-character case is preserved (`bidId` → `treasuryBidId`, `BidId` → `TreasuryBidId`), as is a field's underscore prefix (`_bidId` → `_treasuryBidId`). Works for parameters, properties, and single-declarator fields.
+
+The `<source id>` is the receiver's static type, not the declaring type of the `Id` member. For `treasuryBid.Id` where `Id` is inherited from `BaseEntity`, the fix suggests `TreasuryBid` — what reads locally at the call site — rather than `BaseEntity`.
+
+The fixer always changes the *target* side because the analyzer picks a direction by fix site, not by blaming. If the source annotation is the one that's actually wrong, fix it by hand — a silent cross-domain rewrite would be a behavior change dressed as a fix.
+
+No fix is offered for equality-operand mismatches (`a == b`): both sides are symmetric and there's no distinguished "target" to blame. The mechanical options — replace with `false` / `true`, since cross-domain equality is always false — would be behavior changes, not corrections. Manual resolution is the only safe path there.
+
+Because the right fix depends on intent, SIA001 is deliberately left out of the `dotnet format analyzers` batch: running it would pick option 1 for every occurrence.
+
+
+## When it does not fire
+
+ * Either side's id set overlaps the other's — `[UnionId("Customer", "Product")]` accepts a `Customer` id; a value read as `child.Id` carries every id between the receiver's static type and the declaring type (see "Inheritance and covariant Id tagging" in the readme).
+ * A derived-type id flows into a base-type target: `[Id("PremiumCustomer")]` into `[Id("Customer")]` is allowed when `PremiumCustomer : Customer`.
+ * With wrapper-type inference on, both sides are the same wrapper type and neither carries an explicit attribute. The compiler already checked that.
+ * The source is a literal, a local variable, an untagged method call, or a compound expression (ternary, cast, `??`). Those are deliberately untracked — see "Sources the analyzer can resolve" in the readme.

--- a/docs/SIA002.md
+++ b/docs/SIA002.md
@@ -1,0 +1,62 @@
+# SIA002 — Source missing `[Id]`
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Warning  | Yes      | Yes |
+
+Fires when the source of a flow (argument, right-hand side of an assignment, initializer, `return` value, or one operand of an equality check) carries no id but the target does. The analyzer can't tell whether the value is legitimately an id of the target's domain or a mix-up, so it asks for the source to be tagged.
+
+
+## Example
+
+<!-- snippet: SIA002Example -->
+<a id='snippet-SIA002Example'></a>
+```cs
+public class SIA002Sample
+{
+    // Name doesn't match the `Id`/`XxxId` convention, so no automatic tag.
+    public Guid Raw { get; set; }
+
+    public static void ProcessOrder(Guid orderId) { }
+
+    public void Trigger() =>
+        // SIA002: Raw has no [Id] but is passed to an [Id("Order")] parameter.
+        // Code fix: add [Id("Order")] to Raw's declaration.
+        ProcessOrder(Raw);
+}
+```
+<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L139-L154' title='Snippet source file'>snippet source</a> | <a href='#snippet-SIA002Example' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Build output:
+
+```
+SIA002: property 'SIA002Sample.Raw' has no [Id] but flows to parameter 'orderId' of 'SIA002Sample.ProcessOrder', which is [Id("Order")]. Fix: add [Id("Order")] to property 'SIA002Sample.Raw' (line 4).
+```
+
+The `Fix:` clause names the exact attribute to write and the line of the declaration to put it on. When the declaration is in another file the path is included: `(D:\src\Dto.cs:9)`. When the target is a `[UnionId]`, the suggested attribute is the matching `[UnionId(...)]`.
+
+
+## How to fix
+
+Pick one:
+
+1. **Tag the source.** Add the attribute from the message to the source declaration. This is what the code fix does.
+2. **Rename the source** so the naming convention infers the id: `Raw` → `OrderId`, a parameter `value` → `orderId`. Same effect, no attribute.
+3. **The value does not belong to that domain at all.** Then the call site is wrong and SIA002 has found a bug. Pass the right value.
+
+Apply option 1 across a whole project in one go:
+
+```
+dotnet format analyzers --diagnostics SIA002
+```
+
+For a target tagged `[UnionId("A", "B")]` the IDE offers one fix per option plus the combined `[UnionId("A", "B")]`; the batch command applies the combined form.
+
+
+## When it does not fire
+
+ * The untagged source is a literal, a local variable, an untagged method call, or a compound expression (ternary, cast, `??`). These are `Unknown`, not "missing", and are deliberately ignored — see "Sources the analyzer can resolve" in the readme. `Guid.NewGuid()` and `Guid.Empty` flowing into a tagged property is routine, not a bug.
+ * The source is declared in referenced metadata (BCL, a NuGet package). Library authors can't apply `[Id]`, so the warning would offer nothing actionable.
+ * The source is in a namespace matched by `strongidanalyzer.suppressed_namespaces` (default `System*,Microsoft*`).
+ * The source is a constructor / setter parameter whose name corresponds to the target property: `Tenant(string id) => Id = id;`. The name already expresses the binding, so an extra attribute would be noise.

--- a/docs/SIA003.md
+++ b/docs/SIA003.md
@@ -1,0 +1,66 @@
+# SIA003 — Target missing `[Id]`
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Warning  | Yes      | Yes |
+
+Fires when the source of a flow carries an id but the target (parameter, assignment left-hand side, initializer, property) does not. From that point on the value is an untracked primitive again, so any later mix-up goes unseen. SIA003 asks for the tag to be carried forward.
+
+
+## Example
+
+<!-- snippet: SIA003Example -->
+<a id='snippet-SIA003Example'></a>
+```cs
+public class SIA003Sample
+{
+    // OrderId is tagged "Order" by naming convention.
+    public Guid OrderId { get; set; }
+
+    public static void Consume(Guid value) { }
+
+    public void Trigger() =>
+        // SIA003: OrderId is [Id("Order")] but Consume's parameter has no [Id].
+        // Code fix: add [Id("Order")] to Consume's value parameter.
+        Consume(OrderId);
+}
+```
+<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L156-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-SIA003Example' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Build output:
+
+```
+SIA003: property 'SIA003Sample.OrderId' is [Id("Order")] but flows to parameter 'value' of 'SIA003Sample.Consume', which has no [Id]. Fix: add [Id("Order")] to parameter 'value' of 'SIA003Sample.Consume' (line 6).
+```
+
+The `Fix:` clause names the exact attribute and the line of the declaration to put it on; a declaration in another file is given as `(D:\src\Sink.cs:4)`. A source carrying several ids (a `[UnionId]`, or an inherited `Id` read through a derived receiver) suggests only its *explicit* tags when it has any — convention-derived ids are inferences, and the fix should not promote them into a declaration on the other side.
+
+
+## How to fix
+
+Pick one:
+
+1. **Tag the target.** Add the attribute from the message to the target declaration. This is what the code fix does.
+2. **Rename the target** so the naming convention infers the id: `value` → `orderId`. Same effect, no attribute.
+3. **The target genuinely accepts any id** (a generic helper, a logging sink). Tag it `[UnionId(...)]` with the domains it accepts, or make it `object` / a generic `T` — both of which suppress SIA003 (see below).
+
+Apply option 1 across a whole project:
+
+```
+dotnet format analyzers --diagnostics SIA003
+```
+
+Do not fix SIA003 by removing the attribute from the *source*. That drops the id one step earlier and moves the hole.
+
+
+## When it does not fire
+
+SIA003 is suppressed when the id can't meaningfully survive:
+
+ * **Library metadata targets** — BCL and third-party members (`Dictionary<Guid, T>.this[Guid]`, `Guid.Equals(Guid)`, `object.Equals(object)`). Library authors can't apply `[Id]`.
+ * **`object` parameters / properties / fields** — logging, serialization, message buses. The id is erased through `object` anyway.
+ * **Unconstrained generic type parameters (`T`), and constructed generics still containing one (`TestEntity<T>`, `List<T>`, `Dictionary<Guid, T>`, `T[]`)** — identity methods, container helpers, generic wrappers. The target can't carry a domain tag while T is unbound, so SIA003 would have no place to land a fix.
+ * **Targets in a suppressed namespace** — by default `System*` and `Microsoft*` (`strongidanalyzer.suppressed_namespaces`).
+ * **Equality comparisons** — `==` / `!=` operands are symmetric, so only SIA001 / SIA002 apply.
+ * **Wrapper types travelling intact** (with `strongidanalyzer.infer_wrapper_ids`) — a `CustomerId` struct passed as `CustomerId`, a base type, an interface, `object`, or a substituted `T` leaks no primitive, so nothing is dropped.

--- a/docs/SIA004.md
+++ b/docs/SIA004.md
@@ -1,0 +1,64 @@
+# SIA004 — Ambiguous conventional Id name
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Error    | No       | No |
+
+Fires at the end of compilation when two or more types with the same unqualified name each declare a public member named `Id`. The naming convention (rule 1: `Id` on `Order` ⇒ `"Order"`) would give both members the same id, so an `Order` id from `Sales` would silently satisfy an `Order` id from `Billing`. The analyzer refuses to guess and reports on every colliding declaration.
+
+
+## Example
+
+```cs
+namespace Sales
+{
+    public class Order
+    {
+        public Guid Id { get; set; }   // SIA004
+    }
+}
+
+namespace Billing
+{
+    public class Order
+    {
+        public Guid Id { get; set; }   // SIA004
+    }
+}
+```
+
+Build output (one line per colliding declaration):
+
+```
+SIA004: property 'Sales.Order.Id' and property 'Billing.Order.Id' both infer the conventional Id name "Order" from their declaring type name. Fix: add an explicit [Id("...")] with a distinct value to at least one of them.
+SIA004: property 'Billing.Order.Id' and property 'Sales.Order.Id' both infer the conventional Id name "Order" from their declaring type name. Fix: add an explicit [Id("...")] with a distinct value to at least one of them.
+```
+
+Names are namespace-qualified here, unlike other SIA messages, because the unqualified names are exactly what collided.
+
+
+## How to fix
+
+Give at least one of the members an explicit id that names its domain unambiguously:
+
+```cs
+namespace Billing
+{
+    public class Order
+    {
+        [Id("BillingOrder")]
+        public Guid Id { get; set; }
+    }
+}
+```
+
+Every other `XxxId` member that refers to that domain must then carry the same explicit id (`[Id("BillingOrder")] Guid orderId`), or be renamed `billingOrderId` so rule 2 infers it.
+
+There is no code fix: the analyzer has no way to know which of the two domains deserves the plain name.
+
+
+## What is not ambiguous
+
+ * **Rule 2 collisions.** `Order.CustomerId` and `Invoice.CustomerId` both inferring `"Customer"` is the intended behavior — they refer to the same domain.
+ * **Partial declarations** of one type, or the same type reported twice. Only distinct containing types collide.
+ * **Types in different assemblies.** SIA004 only looks at the compilation being built. A collision with a referenced assembly's type is not reported; tag explicitly if it matters.

--- a/docs/SIA005.md
+++ b/docs/SIA005.md
@@ -1,0 +1,49 @@
+# SIA005 — Redundant `[Id]` attribute
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Warning  | Yes      | Yes |
+
+Fires at the end of compilation when an explicit `[Id("X")]` says exactly what the naming convention would infer without it. The attribute adds nothing, and leaving it in suggests to the next reader that the convention does *not* apply here.
+
+
+## Example
+
+```cs
+public class Customer
+{
+    [Id("Customer")]                // SIA005: `Id` on `Customer` already infers "Customer"
+    public Guid Id { get; set; }
+}
+
+public class Order
+{
+    [Id("Customer")]                // SIA005: `CustomerId` already infers "Customer"
+    public Guid CustomerId { get; set; }
+}
+```
+
+Build output:
+
+```
+SIA005: [Id("Customer")] on property 'Customer.Id' is redundant: the naming convention already infers "Customer". Fix: remove the attribute.
+```
+
+
+## How to fix
+
+Delete the attribute. That is the only fix, and it is safe: the analyzer has already verified the resolved id is identical with and without it.
+
+```
+dotnet format analyzers --diagnostics SIA005
+```
+
+If the attribute was there to *document* the id rather than to change it, the member name already does that job.
+
+
+## When it does not fire
+
+ * The explicit value differs from the convention's: `[Id("Person")] Guid Id` on `Customer` is an override, not a redundancy.
+ * `[UnionId(...)]` — a union never equals a single convention id.
+ * The attribute is what makes the id resolve to that value in the first place. With `strongidanalyzer.infer_suffix_ids` on, `[Id("SourceProduct")] Guid sourceProductId` is only redundant once something *else* vouches for `"SourceProduct"` — a `SourceProduct` type with an `Id` member, or another declaration carrying the same explicit id. The check evaluates the id as if the attribute were already gone; see "Suffix inference and SIA005" in the readme.
+ * With `strongidanalyzer.infer_wrapper_ids` on, an attribute on a wrapper-typed member that repeats the wrapper's tag *is* reported — the type supplies the id, so the attribute is redundant.

--- a/docs/SIA006.md
+++ b/docs/SIA006.md
@@ -1,0 +1,46 @@
+# SIA006 — `[UnionId]` with a single option
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Warning  | Yes      | Yes |
+
+Fires when a `[UnionId(...)]` lists exactly one option. A union of one is `[Id]` under another name, and spelling it as a union misleads the reader into looking for the other domains.
+
+
+## Example
+
+```cs
+public class Cache
+{
+    [UnionId("Customer")]           // SIA006
+    public Guid Key { get; set; }
+}
+```
+
+Build output:
+
+```
+SIA006: [UnionId("Customer")] on property 'Cache.Key' has only one option. Fix: replace it with [Id("Customer")].
+```
+
+
+## How to fix
+
+Replace the attribute with the equivalent `[Id]`:
+
+```cs
+[Id("Customer")]
+public Guid Key { get; set; }
+```
+
+Or, if the member was meant to accept several domains, add the missing options.
+
+```
+dotnet format analyzers --diagnostics SIA006
+```
+
+
+## When it does not fire
+
+ * `[UnionId()]` with no options at all is a different mistake and is not reported as SIA006 — "has only one option" would be untrue, and the fix would write `[Id("")]`, which is [SIA007](SIA007.md).
+ * `[UnionId("A", "A")]` — duplicates are not collapsed before counting.

--- a/docs/SIA007.md
+++ b/docs/SIA007.md
@@ -1,0 +1,39 @@
+# SIA007 — Empty Id tag
+
+| Severity | Code fix | Applies with `dotnet format` |
+|----------|----------|------------------------------|
+| Error    | No       | No |
+
+Fires when an `[Id]` or `[UnionId]` carries a tag that is empty or whitespace. An empty tag names no domain, so nothing can match it and nothing can be reported against it; the attribute would silently turn the member into an untracked primitive while looking tagged.
+
+
+## Example
+
+```cs
+public class Sample
+{
+    [Id("")]                        // SIA007
+    public Guid Key { get; set; }
+
+    [UnionId("Customer", " ")]      // SIA007
+    public Guid Other { get; set; }
+}
+```
+
+Build output:
+
+```
+SIA007: [Id] on property 'Sample.Key' has an empty tag. Fix: supply a non-empty domain name, e.g. [Id("Customer")].
+```
+
+
+## How to fix
+
+Write the name of the domain type the value identifies — normally the entity type's name, matching what the naming convention would produce (`Customer` for `CustomerId`):
+
+```cs
+[Id("Customer")]
+public Guid Key { get; set; }
+```
+
+If the member should not be tracked at all, remove the attribute instead. There is no code fix because the analyzer can't know which domain was intended.

--- a/readme.md
+++ b/readme.md
@@ -393,110 +393,36 @@ The second case flips to SIA005 as soon as something else vouches for `"SourcePr
 
 ## Diagnostics
 
-| ID     | Severity | Code fix | Summary                                                                 |
-|--------|----------|----------|-------------------------------------------------------------------------|
-| SIA001 | Warning  | Yes      | Both sides tagged with different `[Id]` values                          |
-| SIA002 | Warning  | Yes      | Source missing `[Id]`; target has one                                   |
-| SIA003 | Warning  | Yes      | Source has `[Id]`; target missing one                                   |
-| SIA004 | Error    | —        | Two `public Guid Id` declarations collide under the naming convention   |
-| SIA005 | Warning  | Yes      | `[Id("x")]` is redundant — the naming convention already infers `"x"`   |
-| SIA006 | Warning  | Yes      | `[UnionId("x")]` with a single option should be `[Id("x")]`             |
+Each rule has its own page with the message anatomy, every fix option, and the cases where it deliberately stays silent. The page URL is also the diagnostic's help link, so IDEs and SARIF output point straight at it.
+
+| ID                        | Severity | Code fix | Summary                                                                 |
+|---------------------------|----------|----------|-------------------------------------------------------------------------|
+| [SIA001](docs/SIA001.md)  | Warning  | Yes      | Both sides tagged with different `[Id]` values                          |
+| [SIA002](docs/SIA002.md)  | Warning  | Yes      | Source missing `[Id]`; target has one                                   |
+| [SIA003](docs/SIA003.md)  | Warning  | Yes      | Source has `[Id]`; target missing one                                   |
+| [SIA004](docs/SIA004.md)  | Error    | —        | Two `public Guid Id` declarations collide under the naming convention   |
+| [SIA005](docs/SIA005.md)  | Warning  | Yes      | `[Id("x")]` is redundant — the naming convention already infers `"x"`   |
+| [SIA006](docs/SIA006.md)  | Warning  | Yes      | `[UnionId("x")]` with a single option should be `[Id("x")]`             |
+| [SIA007](docs/SIA007.md)  | Error    | —        | `[Id]` / `[UnionId]` tag is empty or whitespace                         |
 
 
-### SIA001 — Id mismatch
+### Reading a diagnostic
 
-Fires when both operands carry `[Id]` and the id values differ. The analyzer sees an unambiguous cross-domain flow (e.g. a `Customer` id passed where an `Order` id is expected) and refuses it.
+Every message names both declarations involved, states the attribute to write, and says where to write it, so the build log alone is enough to act on — no IDE hover required:
 
-<!-- snippet: SIA001Example -->
-<a id='snippet-SIA001Example'></a>
-```cs
-public class SIA001Sample
-{
-    // CustomerId is tagged "Customer" by naming convention.
-    public Guid CustomerId { get; set; }
-
-    public static void ProcessOrder(Guid orderId) { }
-
-    public void Trigger() =>
-        // SIA001: argument tagged [Id("Customer")] passed to parameter tagged [Id("Order")].
-        ProcessOrder(CustomerId);
-}
 ```
-<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L123-L137' title='Snippet source file'>snippet source</a> | <a href='#snippet-SIA001Example' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-
-#### Code fixes
-
-For flow-style mismatches (argument, assignment, property/field initializer) the analyzer attaches the **target** declaration as the fix site and offers:
-
- * **Change attribute on `<kind> '<name>'` to `[Id("<source id>")]`** — when the target already carries an explicit `[Id]` / `[UnionId]`, replaces it with the source's id.
- * **Add `[Id("<source id>")]` to `<kind> '<name>'`** — when the target is untagged (its current id came from naming convention), adds the attribute.
- * **Rename `<kind> '<name>'` to `<sourceTag>Id`** — when the target has no explicit attribute and its name matches the `XxxId` convention. First-character case is preserved (`bidId` → `treasuryBidId`, `BidId` → `TreasuryBidId`), as is a field's underscore prefix (`_bidId` → `_treasuryBidId`). Works for parameters, properties, and single-declarator fields.
-
-The `<source id>` is the receiver's static type, not the declaring type of the `Id` member. For `treasuryBid.Id` where `Id` is inherited from `BaseEntity`, the fix suggests `TreasuryBid` — what reads locally at the call site — rather than `BaseEntity`.
-
-The fixer always changes the *target* side because the analyzer picks a direction by fix site, not by blaming. If the source annotation is the one that's actually wrong, fix it by hand — a silent cross-domain rewrite would be a behavior change dressed as a fix.
-
-No fix is offered for equality-operand mismatches (`a == b`): both sides are symmetric and there's no distinguished "target" to blame. The mechanical options — replace with `false` / `true`, since cross-domain equality is always false — would be behavior changes, not corrections. Manual resolution is the only safe path there.
-
-
-### SIA002 — Source missing `[Id]`
-
-Fires when the source (argument, right-hand side of an assignment, initializer, or one operand of an equality check) has no `[Id]` but the target carries one. The fix adds `[Id("<target value>")]` to the source symbol's declaration.
-
-<!-- snippet: SIA002Example -->
-<a id='snippet-SIA002Example'></a>
-```cs
-public class SIA002Sample
-{
-    // Name doesn't match the `Id`/`XxxId` convention, so no automatic tag.
-    public Guid Raw { get; set; }
-
-    public static void ProcessOrder(Guid orderId) { }
-
-    public void Trigger() =>
-        // SIA002: Raw has no [Id] but is passed to an [Id("Order")] parameter.
-        // Code fix: add [Id("Order")] to Raw's declaration.
-        ProcessOrder(Raw);
-}
+SIA002: property 'Order.CustomerRef' has no [Id] but flows to parameter 'customerId' of 'Customers.Load', which is [Id("Customer")]. Fix: add [Id("Customer")] to property 'Order.CustomerRef' (line 12).
 ```
-<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L139-L154' title='Snippet source file'>snippet source</a> | <a href='#snippet-SIA002Example' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
 
-Suppressed when the untagged source lives in referenced metadata (e.g. `Guid.Empty`, a third-party property) — library authors can't apply `[Id]`, so the warning would offer no actionable fix.
+The location in the `Fix:` clause is the *declaration* to edit, which is often not where the warning is reported. `(line 12)` means the same file as the warning; a declaration elsewhere is given as `(D:\src\Order.cs:12)`. Equality checks read `is compared with` instead of `flows to`. MSBuild appends each rule's help link after the message, so the build log also carries the URL of the rule's page.
 
+The mechanically-fixable rules can be applied across a project from the command line, without an IDE, because the code fixes ship inside the analyzer package:
 
-### SIA003 — Target missing `[Id]`
-
-Fires when the source carries `[Id]` but the target (parameter, assignment left-hand side, initializer) does not. The fix adds `[Id("<source value>")]` to the target symbol's declaration.
-
-<!-- snippet: SIA003Example -->
-<a id='snippet-SIA003Example'></a>
-```cs
-public class SIA003Sample
-{
-    // OrderId is tagged "Order" by naming convention.
-    public Guid OrderId { get; set; }
-
-    public static void Consume(Guid value) { }
-
-    public void Trigger() =>
-        // SIA003: OrderId is [Id("Order")] but Consume's parameter has no [Id].
-        // Code fix: add [Id("Order")] to Consume's value parameter.
-        Consume(OrderId);
-}
 ```
-<sup><a href='/src/StrongIdAnalyzer.Tests/Samples.cs#L156-L171' title='Snippet source file'>snippet source</a> | <a href='#snippet-SIA003Example' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
+dotnet format analyzers --diagnostics SIA002 SIA003 SIA005 SIA006
+```
 
-SIA003 is suppressed when the id can't meaningfully survive:
-
- * **Library metadata targets** — BCL and third-party members (`Dictionary<Guid, T>.this[Guid]`, `Guid.Equals(Guid)`, `object.Equals(object)`). Library authors can't apply `[Id]`.
- * **`object` parameters / properties / fields** — logging, serialization, message buses. The id is erased through `object` anyway.
- * **Unconstrained generic type parameters (`T`), and constructed generics still containing one (`TestEntity<T>`, `List<T>`, `Dictionary<Guid, T>`, `T[]`)** — identity methods, container helpers, generic wrappers. The target can't carry a domain tag while T is unbound, so SIA003 would have no place to land a fix.
- * **Targets in a suppressed namespace** — by default `System*` and `Microsoft*` (see below).
- * **Equality comparisons** — `==` / `!=` operands are symmetric, so only SIA001 / SIA002 apply.
+SIA001 is left out on purpose: it has two competing fixes (retag the target, or pass a different value) and only a human can tell which one is the bug. See [SIA001](docs/SIA001.md).
 
 
 ## `[UnionId(...)]`

--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -3096,7 +3096,7 @@ public class IdMismatchAnalyzerTests
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
         await Assert.That(diagnostics[0].GetMessage()).IsEqualTo(
-            """Value with [Id("Group")] is assigned to a target with [Id("AccessGroup")]""");
+            """property 'Group.Id' is [Id("Group")] and flows to field 'AccessRule._accessGroupId', which is [Id("AccessGroup")]. Fix: apply [Id("Group")] to field 'AccessRule._accessGroupId' (line 15), or pass a value tagged [Id("AccessGroup")].""");
     }
 
     [Test]
@@ -3139,7 +3139,7 @@ public class IdMismatchAnalyzerTests
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo("SIA001");
         await Assert.That(diagnostics[0].GetMessage()).IsEqualTo(
-            """Value with [Id("Group")] is assigned to a target with [Id("AccessGroup")]""");
+            """property 'Group.Id' is [Id("Group")] and flows to field 'AccessRule._accessGroupId', which is [Id("AccessGroup")]. Fix: apply [Id("Group")] to field 'AccessRule._accessGroupId' (line 20), or pass a value tagged [Id("AccessGroup")].""");
     }
 
     [Test]

--- a/src/StrongIdAnalyzer.Tests/MessageTests.cs
+++ b/src/StrongIdAnalyzer.Tests/MessageTests.cs
@@ -1,0 +1,314 @@
+// Exact-text assertions for every diagnostic message. The message is the only part of a
+// diagnostic that survives into build output, so its wording is a contract: it has to
+// name both declarations, spell out the attribute to write, and say where the fix
+// lands. A change here is a change to what CI logs and AI agents get to read.
+public class MessageTests
+{
+    [Test]
+    public async Task SIA001_Argument()
+    {
+        var source =
+            """
+            using System;
+            public class Customer { public Guid Id { get; set; } }
+            public class OrderService
+            {
+                public static void Place(Guid orderId) { }
+                public void Run(Customer customer) => Place(customer.Id);
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA001");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """property 'Customer.Id' is [Id("Customer")] and flows to parameter 'orderId' of 'OrderService.Place', which is [Id("Order")]. Fix: apply [Id("Customer")] to parameter 'orderId' of 'OrderService.Place' (line 5), or pass a value tagged [Id("Order")].""");
+    }
+
+    [Test]
+    public async Task SIA001_Equality()
+    {
+        var source =
+            """
+            using System;
+            public class Customer { public Guid Id { get; set; } }
+            public class Checks
+            {
+                public static bool Same(Customer customer, Guid orderId) => customer.Id == orderId;
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA001");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """property 'Customer.Id' is [Id("Customer")] and is compared with parameter 'orderId' of 'Checks.Same', which is [Id("Order")]. Fix: apply [Id("Customer")] to parameter 'orderId' of 'Checks.Same' (line 5), or pass a value tagged [Id("Order")].""");
+    }
+
+    [Test]
+    public async Task SIA001_NeitherSideEditable_OnlySuggestsValue()
+    {
+        // Wrapper-derived tags have no declaration to edit, so the fix clause can only
+        // ask for a different value.
+        var source =
+            """
+            using System;
+            public readonly record struct CustomerId(Guid Value);
+            public readonly record struct OrderId(Guid Value);
+            public class Service
+            {
+                public static void Place(OrderId orderId) { }
+                public static void Run(CustomerId customerId) => Place(new OrderId(customerId.Value));
+            }
+            """;
+
+        var diagnostics = await Run(("Service.cs", source), wrappers: true);
+        var sia001 = diagnostics.Where(_ => _.Id == "SIA001").ToArray();
+
+        await Assert.That(sia001.Length).IsEqualTo(1);
+        await Assert.That(sia001[0].GetMessage()).IsEqualTo(
+            """property 'CustomerId.Value' is [Id("Customer")] and flows to parameter 'Value' of 'OrderId.OrderId', which is [Id("Order")]. Fix: pass a value tagged [Id("Order")].""");
+    }
+
+    [Test]
+    public async Task SIA002_SingleTag()
+    {
+        var source =
+            """
+            using System;
+            public class Sample
+            {
+                public Guid Raw { get; set; }
+                public static void Place(Guid orderId) { }
+                public void Run() => Place(Raw);
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA002");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """property 'Sample.Raw' has no [Id] but flows to parameter 'orderId' of 'Sample.Place', which is [Id("Order")]. Fix: add [Id("Order")] to property 'Sample.Raw' (line 4).""");
+    }
+
+    [Test]
+    public async Task SIA002_UnionTarget_SuggestsUnionId()
+    {
+        var source =
+            """
+            using System;
+            public class Sample
+            {
+                public Guid Raw { get; set; }
+                public static void Lookup([UnionId("Customer", "Product")] Guid key) { }
+                public void Run() => Lookup(Raw);
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA002");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """property 'Sample.Raw' has no [Id] but flows to parameter 'key' of 'Sample.Lookup', which is [Id("Customer/Product")]. Fix: add [UnionId("Customer", "Product")] to property 'Sample.Raw' (line 4).""");
+    }
+
+    [Test]
+    public async Task SIA002_Equality()
+    {
+        var source =
+            """
+            using System;
+            public class Sample
+            {
+                public Guid Raw { get; set; }
+                public Guid OrderId { get; set; }
+                public bool Same() => Raw == OrderId;
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA002");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """property 'Sample.Raw' has no [Id] but is compared with property 'Sample.OrderId', which is [Id("Order")]. Fix: add [Id("Order")] to property 'Sample.Raw' (line 4).""");
+    }
+
+    [Test]
+    public async Task SIA003_SameFile()
+    {
+        var source =
+            """
+            using System;
+            public class Sample
+            {
+                public Guid OrderId { get; set; }
+                public static void Consume(Guid value) { }
+                public void Run() => Consume(OrderId);
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA003");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """property 'Sample.OrderId' is [Id("Order")] but flows to parameter 'value' of 'Sample.Consume', which has no [Id]. Fix: add [Id("Order")] to parameter 'value' of 'Sample.Consume' (line 5).""");
+    }
+
+    [Test]
+    public async Task SIA003_OtherFile_NamesThePath()
+    {
+        var sink =
+            """
+            using System;
+            public static class Sink
+            {
+                public static void Consume(Guid value) { }
+            }
+            """;
+        var caller =
+            """
+            using System;
+            public class Sample
+            {
+                public Guid OrderId { get; set; }
+                public void Run() => Sink.Consume(OrderId);
+            }
+            """;
+
+        var diagnostics = await Run(("Sink.cs", sink), ("Sample.cs", caller));
+        var sia003 = diagnostics.Where(_ => _.Id == "SIA003").ToArray();
+
+        await Assert.That(sia003.Length).IsEqualTo(1);
+        await Assert.That(sia003[0].GetMessage()).IsEqualTo(
+            """property 'Sample.OrderId' is [Id("Order")] but flows to parameter 'value' of 'Sink.Consume', which has no [Id]. Fix: add [Id("Order")] to parameter 'value' of 'Sink.Consume' (Sink.cs:4).""");
+    }
+
+    [Test]
+    public async Task SIA004_NamesBothDeclarations()
+    {
+        var source =
+            """
+            using System;
+            namespace Sales { public class Order { public Guid Id { get; set; } } }
+            namespace Billing { public class Order { public Guid Id { get; set; } } }
+            """;
+
+        var diagnostics = await Run(("Orders.cs", source));
+        var messages = diagnostics
+            .Where(_ => _.Id == "SIA004")
+            .Select(_ => _.GetMessage())
+            .OrderBy(_ => _)
+            .ToArray();
+
+        await Assert.That(messages).IsEquivalentTo(
+        [
+            """property 'Billing.Order.Id' and property 'Sales.Order.Id' both infer the conventional Id name "Order" from their declaring type name. Fix: add an explicit [Id("...")] with a distinct value to at least one of them.""",
+            """property 'Sales.Order.Id' and property 'Billing.Order.Id' both infer the conventional Id name "Order" from their declaring type name. Fix: add an explicit [Id("...")] with a distinct value to at least one of them."""
+        ]);
+    }
+
+    [Test]
+    public async Task SIA005()
+    {
+        var source =
+            """
+            using System;
+            public class Customer
+            {
+                [Id("Customer")]
+                public Guid Id { get; set; }
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA005");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """[Id("Customer")] on property 'Customer.Id' is redundant: the naming convention already infers "Customer". Fix: remove the attribute.""");
+    }
+
+    [Test]
+    public async Task SIA006()
+    {
+        var source =
+            """
+            using System;
+            public class Sample
+            {
+                [UnionId("Customer")]
+                public Guid Key { get; set; }
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA006");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """[UnionId("Customer")] on property 'Sample.Key' has only one option. Fix: replace it with [Id("Customer")].""");
+    }
+
+    [Test]
+    public async Task SIA007()
+    {
+        var source =
+            """
+            using System;
+            public class Sample
+            {
+                [Id("")]
+                public Guid Key { get; set; }
+            }
+            """;
+
+        var diagnostic = await Single(source, "SIA007");
+
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            """[Id] on property 'Sample.Key' has an empty tag. Fix: supply a non-empty domain name, e.g. [Id("Customer")].""");
+    }
+
+    [Test]
+    public async Task EveryRule_HasHelpLinkAndDescription()
+    {
+        foreach (var descriptor in new IdMismatchAnalyzer().SupportedDiagnostics)
+        {
+            await Assert.That(descriptor.HelpLinkUri)
+                .IsEqualTo($"https://github.com/SimonCropp/StrongIdAnalyzer/blob/main/docs/{descriptor.Id}.md");
+            await Assert.That(descriptor.Description.ToString().Length).IsGreaterThan(0);
+        }
+    }
+
+    static async Task<Diagnostic> Single(string source, string id)
+    {
+        var diagnostics = await Run(("Sample.cs", source));
+        var matching = diagnostics.Where(_ => _.Id == id).ToArray();
+        await Assert.That(matching.Length).IsEqualTo(1);
+        return matching[0];
+    }
+
+    static Task<ImmutableArray<Diagnostic>> Run(params (string Path, string Source)[] files) =>
+        Run(files, wrappers: false);
+
+    static Task<ImmutableArray<Diagnostic>> Run((string Path, string Source) file, bool wrappers) =>
+        Run([file], wrappers);
+
+    static Task<ImmutableArray<Diagnostic>> Run((string Path, string Source)[] files, bool wrappers)
+    {
+        var compilation = CSharpCompilation.Create(
+            "Tests",
+            files.Select(_ => CSharpSyntaxTree.ParseText(_.Source, path: _.Path)),
+            TrustedReferences.All,
+            new(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(new IdAttributeGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var updated, out _);
+
+        var errors = updated.GetDiagnostics().Where(_ => _.Severity == DiagnosticSeverity.Error).ToArray();
+        if (errors.Length > 0)
+        {
+            throw new(string.Join(Environment.NewLine, errors.Select(_ => _.ToString())));
+        }
+
+        var options = new Dictionary<string, string>();
+        if (wrappers)
+        {
+            options["strongidanalyzer.infer_wrapper_ids"] = "true";
+        }
+
+        var analyzerOptions = new AnalyzerOptions([], new TestAnalyzerConfigOptionsProvider(options));
+        return updated
+            .WithAnalyzers([new IdMismatchAnalyzer()], analyzerOptions)
+            .GetAnalyzerDiagnosticsAsync();
+    }
+}

--- a/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
+++ b/src/StrongIdAnalyzer/IdMismatchAnalyzer.cs
@@ -326,9 +326,10 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
 
             foreach (var symbol in distinct)
             {
+                var others = distinct.Where(_ => !SymbolEqualityComparer.Default.Equals(_, symbol));
                 foreach (var reference in symbol.DeclaringSyntaxReferences)
                 {
-                    Rules.ReportAmbiguousConvention(context, reference.ToLocation(), entry.Key);
+                    Rules.ReportAmbiguousConvention(context, reference.ToLocation(), symbol, others, entry.Key);
                 }
             }
         }
@@ -345,7 +346,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            Rules.ReportRedundant(context, candidate.Reference.ToLocation(), candidate.Value);
+            Rules.ReportRedundant(context, candidate.Reference.ToLocation(), candidate.Symbol, candidate.Value);
         }
     }
 
@@ -703,10 +704,13 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             Rules.ReportMismatch(
                 context,
                 operation.Syntax.GetLocation(),
+                leftSymbol,
                 FixSite(leftSymbol, leftInfo, config),
                 leftInfo,
+                rightSymbol,
                 FixSite(rightSymbol, rightInfo, config),
-                rightInfo);
+                rightInfo,
+                relation: "is compared with");
             return;
         }
 
@@ -717,14 +721,14 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         if (leftInfo.State == IdState.Present &&
             rightInfo.State == IdState.NotPresent)
         {
-            ReportMissingOnBinarySide(context, operation.RightOperand, rightSymbol, leftInfo, config);
+            ReportMissingOnBinarySide(context, operation.RightOperand, rightSymbol, leftSymbol, leftInfo, config);
             return;
         }
 
         if (leftInfo.State == IdState.NotPresent &&
             rightInfo.State == IdState.Present)
         {
-            ReportMissingOnBinarySide(context, operation.LeftOperand, leftSymbol, rightInfo, config);
+            ReportMissingOnBinarySide(context, operation.LeftOperand, leftSymbol, rightSymbol, rightInfo, config);
         }
     }
 
@@ -732,6 +736,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         IOperation untaggedOperand,
         ISymbol? untaggedSymbol,
+        ISymbol? taggedSymbol,
         IdInfo taggedInfo,
         Config config)
     {
@@ -759,7 +764,9 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             context,
             untaggedOperand.Syntax.GetLocation(),
             untaggedSymbol,
-            taggedInfo);
+            taggedSymbol,
+            taggedInfo,
+            relation: "is compared with");
     }
 
     static void AnalyzeArgument(OperationAnalysisContext context, Config config)
@@ -2328,8 +2335,10 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
                 Rules.ReportMismatch(
                     context,
                     location,
+                    sourceSymbol,
                     FixSite(sourceSymbol, source, config),
                     source,
+                    targetSymbol,
                     FixSite(targetSymbol, target, config),
                     target);
             }
@@ -2375,7 +2384,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             // Fix site is the source symbol's declaration (add Id matching target). The
             // codefix splits the pipe-delimited tags and offers one fix per option plus a
             // combined [UnionId(...)] when the target is multi-tag.
-            Rules.ReportMissingSource(context, location, sourceSymbol, target);
+            Rules.ReportMissingSource(context, location, sourceSymbol, targetSymbol, target);
             return;
         }
 
@@ -2413,7 +2422,7 @@ public class IdMismatchAnalyzer : DiagnosticAnalyzer
             }
 
             // Fix site is the target symbol's declaration (add Id matching source).
-            Rules.ReportDropped(context, location, targetSymbol, source);
+            Rules.ReportDropped(context, location, sourceSymbol, source, targetSymbol);
         }
     }
 

--- a/src/StrongIdAnalyzer/Rules.cs
+++ b/src/StrongIdAnalyzer/Rules.cs
@@ -19,63 +19,83 @@ static class Rules
     public const string TargetValueKey = "IdValueTarget";
     public const string SourceValueKey = "IdValueSource";
 
+    // Messages name both symbols and spell out the fix. Build output (and anything that
+    // reads it — CI logs, AI agents) only ever sees the message string, so it has to
+    // carry enough for a reader to act without opening an IDE: which declaration is
+    // wrong, what to put on it, and where that declaration lives.
+    const string helpRoot = "https://github.com/SimonCropp/StrongIdAnalyzer/blob/main/docs/";
+
     static readonly DiagnosticDescriptor idMismatch = new(
         id: "SIA001",
         title: "Id type mismatch",
-        messageFormat: "Value with [Id(\"{0}\")] is assigned to a target with [Id(\"{1}\")]",
+        messageFormat: "{0} is [Id(\"{1}\")] and {2} {3}, which is [Id(\"{4}\")]. {5}.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        description: "A value tagged with one domain id flows into a target tagged with a different domain id. Either the target's [Id] is wrong, or the wrong value is being passed. Change whichever side is mistaken so both carry the same id.",
+        helpLinkUri: helpRoot + "SIA001.md");
 
     static readonly DiagnosticDescriptor missingSourceId = new(
         id: "SIA002",
         title: "Source has no Id while target requires one",
-        messageFormat: "Value has no [Id] attribute but is assigned to a target with [Id(\"{0}\")]",
+        messageFormat: "{0} has no [Id] but {1} {2}, which is [Id(\"{3}\")]. Fix: add {4} to {0}{5}.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        description: "An untagged value flows into a target that carries an [Id]. Add a matching [Id] to the source declaration so the analyzer can track the value, or rename it to follow the Id / XxxId convention. Apply mechanically with: dotnet format analyzers --diagnostics SIA002.",
+        helpLinkUri: helpRoot + "SIA002.md");
 
     static readonly DiagnosticDescriptor droppedId = new(
         id: "SIA003",
         title: "Source has Id while target has none",
-        messageFormat: "Value with [Id(\"{0}\")] is assigned to a target without an [Id] attribute",
+        messageFormat: "{0} is [Id(\"{1}\")] but {2} {3}, which has no [Id]. Fix: add {4} to {3}{5}.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        description: "A tagged value flows into a target that carries no [Id], so the domain id is lost from that point on. Add a matching [Id] to the target declaration, or rename it to follow the Id / XxxId convention. Apply mechanically with: dotnet format analyzers --diagnostics SIA003.",
+        helpLinkUri: helpRoot + "SIA003.md");
 
     static readonly DiagnosticDescriptor ambiguousConvention = new(
         id: "SIA004",
         title: "Ambiguous conventional Id name",
-        messageFormat: "Multiple declarations map to the conventional Id name \"{0}\"; add an explicit [Id(\"...\")] to at least one to disambiguate",
+        messageFormat: "{0} and {1} both infer the conventional Id name \"{2}\" from their declaring type name. Fix: add an explicit [Id(\"...\")] with a distinct value to at least one of them.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
+        description: "Two types with the same unqualified name each declare a member named Id, so the naming convention would give both members the same domain id. Add an explicit [Id(\"...\")] to at least one of the members to disambiguate.",
+        helpLinkUri: helpRoot + "SIA004.md",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 
     static readonly DiagnosticDescriptor redundantId = new(
         id: "SIA005",
         title: "Redundant [Id] attribute",
-        messageFormat: "[Id(\"{0}\")] is redundant because the naming convention already infers this value",
+        messageFormat: "[Id(\"{0}\")] on {1} is redundant: the naming convention already infers \"{0}\". Fix: remove the attribute.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
+        description: "The explicit [Id] repeats exactly what the naming convention infers from the member and type names. Remove the attribute. Apply mechanically with: dotnet format analyzers --diagnostics SIA005.",
+        helpLinkUri: helpRoot + "SIA005.md",
         customTags: [WellKnownDiagnosticTags.CompilationEnd]);
 
     static readonly DiagnosticDescriptor singletonUnion = new(
         id: "SIA006",
         title: "[UnionId] with a single option should be [Id]",
-        messageFormat: "[UnionId(\"{0}\")] has only one option; use [Id(\"{0}\")] instead",
+        messageFormat: "[UnionId(\"{0}\")] on {1} has only one option. Fix: replace it with [Id(\"{0}\")].",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        description: "[UnionId] expresses a choice between several domain ids; with a single option it is just [Id]. Replace it. Apply mechanically with: dotnet format analyzers --diagnostics SIA006.",
+        helpLinkUri: helpRoot + "SIA006.md");
 
     static readonly DiagnosticDescriptor emptyTag = new(
         id: "SIA007",
         title: "Id tag must not be empty or whitespace",
-        messageFormat: "[{0}] tag must not be empty or whitespace",
+        messageFormat: "[{0}] on {1} has an empty tag. Fix: supply a non-empty domain name, e.g. [{0}(\"Customer\")].",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        description: "An [Id] or [UnionId] tag that is empty or whitespace cannot identify a domain. Supply the name of the domain type the value identifies.",
+        helpLinkUri: helpRoot + "SIA007.md");
 
     public static readonly ImmutableArray<DiagnosticDescriptor> All =
         [idMismatch, missingSourceId, droppedId, ambiguousConvention, redundantId, singletonUnion, emptyTag];
@@ -84,20 +104,27 @@ static class Rules
     // offer to fix either side — slot 0 is always the target, slot 1 the source. Slots
     // without a user-owned declaration (library refs, locals) hold Location.None as a
     // sentinel so the indexes stay stable; the fixer checks IsInSource before offering.
+    //
+    // `sourceSymbol` / `targetSymbol` are what the message names; `sourceFixSite` /
+    // `targetFixSite` are the declarations the fixer may edit (null when the tag came
+    // from a wrapper type rather than a declaration).
     public static void ReportMismatch(
         OperationAnalysisContext context,
         Location location,
         ISymbol? sourceSymbol,
+        ISymbol? sourceFixSite,
         IdInfo source,
         ISymbol? targetSymbol,
-        IdInfo target) =>
+        ISymbol? targetFixSite,
+        IdInfo target,
+        string relation = "flows to") =>
         context.ReportDiagnostic(Diagnostic.Create(
             idMismatch,
             location,
             additionalLocations:
             [
-                targetSymbol.ResolveDeclarationLocation(),
-                sourceSymbol.ResolveDeclarationLocation()
+                targetFixSite.ResolveDeclarationLocation(),
+                sourceFixSite.ResolveDeclarationLocation()
             ],
             properties: ImmutableDictionary<string, string?>.Empty
                 // Kept for backward-compat: older fixer versions read IdValue and apply
@@ -105,39 +132,112 @@ static class Rules
                 .Add(ValueKey, source.FirstValue)
                 .Add(TargetValueKey, source.FirstValue)
                 .Add(SourceValueKey, target.FirstValue),
-            messageArgs: [source.Format(), target.Format()]));
+            messageArgs:
+            [
+                Describe(sourceSymbol),
+                source.Format(),
+                relation,
+                Describe(targetSymbol),
+                target.Format(),
+                MismatchFix(location, sourceSymbol, sourceFixSite, source, targetSymbol, targetFixSite, target)
+            ]));
+
+    // The fix clause prefers retagging the target (matches the fixer's default), falls
+    // back to the source when only that side is editable, and otherwise can only ask
+    // for a different value.
+    static string MismatchFix(
+        Location location,
+        ISymbol? sourceSymbol,
+        ISymbol? sourceFixSite,
+        IdInfo source,
+        ISymbol? targetSymbol,
+        ISymbol? targetFixSite,
+        IdInfo target)
+    {
+        if (targetFixSite.IsEditable())
+        {
+            return $"Fix: apply {FormatAttribute(source.Tags)} to {Describe(targetSymbol)}{Site(location, targetFixSite)}, or pass a value tagged {FormatAttribute(target.Tags)}";
+        }
+
+        if (sourceFixSite.IsEditable())
+        {
+            return $"Fix: apply {FormatAttribute(target.Tags)} to {Describe(sourceSymbol)}{Site(location, sourceFixSite)}, or pass a value tagged {FormatAttribute(target.Tags)}";
+        }
+
+        return $"Fix: pass a value tagged {FormatAttribute(target.Tags)}";
+    }
 
     // SIA002. `fixTarget` is the untagged side's declaration — the codefix adds an [Id]
-    // there matching `info`, which is the tagged side's info.
+    // there matching `info`, which is the tagged side's info. `taggedSymbol` is only
+    // named in the message.
     public static void ReportMissingSource(
         OperationAnalysisContext context,
         Location location,
         ISymbol fixTarget,
-        IdInfo info) =>
-        context.ReportDiagnostic(CreateFixable(missingSourceId, location, fixTarget, info));
+        ISymbol? taggedSymbol,
+        IdInfo info,
+        string relation = "flows to") =>
+        context.ReportDiagnostic(CreateFixable(
+            missingSourceId,
+            location,
+            fixTarget,
+            info,
+            messageArgs: (fixTags, displayTags) =>
+            [
+                Describe(fixTarget),
+                relation,
+                Describe(taggedSymbol),
+                displayTags,
+                FormatAttribute(fixTags),
+                Site(location, fixTarget)
+            ]));
 
     // SIA003. Mirror of SIA002: `fixTarget` is the untagged target's declaration and
     // `info` the tagged source's info.
     public static void ReportDropped(
         OperationAnalysisContext context,
         Location location,
-        ISymbol fixTarget,
-        IdInfo info) =>
-        context.ReportDiagnostic(CreateFixable(droppedId, location, fixTarget, info));
+        ISymbol? taggedSymbol,
+        IdInfo info,
+        ISymbol fixTarget) =>
+        context.ReportDiagnostic(CreateFixable(
+            droppedId,
+            location,
+            fixTarget,
+            info,
+            messageArgs: (fixTags, displayTags) =>
+            [
+                Describe(taggedSymbol),
+                displayTags,
+                "flows to",
+                Describe(fixTarget),
+                FormatAttribute(fixTags),
+                Site(location, fixTarget)
+            ]));
 
     // SIA004. Compilation-end: several declarations infer the same conventional name.
+    // `others` are the colliding declarations, named in the message so the reader can
+    // find the counterpart without a second search.
     public static void ReportAmbiguousConvention(
         CompilationAnalysisContext context,
         Location location,
+        ISymbol symbol,
+        IEnumerable<ISymbol> others,
         string conventionName) =>
-        context.ReportDiagnostic(Diagnostic.Create(ambiguousConvention, location, conventionName));
+        context.ReportDiagnostic(Diagnostic.Create(
+            ambiguousConvention,
+            location,
+            Describe(symbol, qualifiedFormat),
+            string.Join(", ", others.Select(_ => Describe(_, qualifiedFormat))),
+            conventionName));
 
     // SIA005. Compilation-end: an explicit [Id] repeating what convention already infers.
     public static void ReportRedundant(
         CompilationAnalysisContext context,
         Location location,
+        ISymbol symbol,
         string value) =>
-        context.ReportDiagnostic(Diagnostic.Create(redundantId, location, value));
+        context.ReportDiagnostic(Diagnostic.Create(redundantId, location, value, Describe(symbol)));
 
     // SIA006. The single option travels in the property bag so the fixer can rewrite
     // [UnionId("X")] to [Id("X")] without re-parsing the attribute.
@@ -149,14 +249,14 @@ static class Rules
             singletonUnion,
             location,
             properties: ImmutableDictionary<string, string?>.Empty.Add(ValueKey, singleValue),
-            messageArgs: singleValue));
+            messageArgs: [singleValue, Describe(context.Symbol)]));
 
     // SIA007. No codefix — an empty tag doesn't say what the user meant.
     public static void ReportEmptyTag(
         SymbolAnalysisContext context,
         Location location,
         string attributeName) =>
-        context.ReportDiagnostic(Diagnostic.Create(emptyTag, location, attributeName));
+        context.ReportDiagnostic(Diagnostic.Create(emptyTag, location, attributeName, Describe(context.Symbol)));
 
     // Shared shape for SIA002/SIA003: the diagnostic carries the tags to apply plus the
     // declaration to apply them to.
@@ -164,28 +264,109 @@ static class Rules
         DiagnosticDescriptor rule,
         Location location,
         ISymbol? fixTarget,
-        IdInfo info)
+        IdInfo info,
+        Func<ImmutableArray<string>, string, object[]> messageArgs)
     {
         // Pipe-delimited so a UnionId source can drive multiple codefix options (one
-        // [Id(x)] per tag + one combined [UnionId(...)]). Pipe is the same separator
-        // used in the rendered message — safe because tag values are identifier-like.
+        // [Id(x)] per tag + one combined [UnionId(...)]). Pipe is safe because tag
+        // values are identifier-like.
         //
         // When the tagged side carries any explicit [Id]/[UnionId] tags we offer ONLY
         // those as fix suggestions — convention-derived tags (member name, receiver
         // type) on the same side are inferences, not declarations, and proposing them
         // as add-fixes would override the deliberate annotation that's already there.
         // The diagnostic message still shows the full effective tag set so the reader
-        // sees what the analyzer matched against.
+        // sees what the analyzer matched against, but its Fix clause spells out the
+        // same attribute the fixer would write.
         var fixTags = info.ExplicitTags.IsDefaultOrEmpty ? info.Tags : info.ExplicitTags;
         var joined = fixTags.IsDefaultOrEmpty ? "" : string.Join("|", fixTags);
-        var displayJoined = info.Tags.IsDefaultOrEmpty ? "" : string.Join("|", info.Tags);
         return Diagnostic.Create(
             rule,
             location,
             additionalLocations: GetAdditionalLocations(fixTarget),
             properties: ImmutableDictionary<string, string?>.Empty.Add(ValueKey, joined),
-            messageArgs: displayJoined);
+            messageArgs: messageArgs(fixTags, info.Format()));
     }
+
+    // The attribute the reader should write: one tag → [Id("X")], several → the
+    // equivalent [UnionId("X", "Y")].
+    static string FormatAttribute(ImmutableArray<string> tags)
+    {
+        if (tags.IsDefaultOrEmpty)
+        {
+            return "[Id(\"...\")]";
+        }
+
+        if (tags.Length == 1)
+        {
+            return $"[Id(\"{tags[0]}\")]";
+        }
+
+        return $"[UnionId({string.Join(", ", tags.Select(_ => $"\"{_}\""))})]";
+    }
+
+    static readonly SymbolDisplayFormat memberFormat = new(
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        memberOptions: SymbolDisplayMemberOptions.IncludeContainingType);
+
+    // SIA004 is precisely the case where two members share an unqualified name, so it
+    // needs the namespace to tell them apart.
+    static readonly SymbolDisplayFormat qualifiedFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        memberOptions: SymbolDisplayMemberOptions.IncludeContainingType);
+
+    // Human-readable name for a symbol in a message: `property 'Order.CustomerId'`,
+    // `parameter 'orderId' of 'OrderService.Place'`, `return value of 'Repo.Load'`.
+    // Null (a wrapper-typed expression, a literal) reads as plain `value`.
+    static string Describe(ISymbol? symbol) =>
+        Describe(symbol, memberFormat);
+
+    static string Describe(ISymbol? symbol, SymbolDisplayFormat format)
+    {
+        switch (symbol)
+        {
+            case null:
+                return "value";
+            case IParameterSymbol parameter:
+                return $"parameter '{parameter.Name}' of '{parameter.ContainingSymbol.ToDisplayString(format)}'";
+            case IPropertySymbol property:
+                return $"property '{property.ToDisplayString(format)}'";
+            case IFieldSymbol field:
+                return $"field '{field.ToDisplayString(format)}'";
+            case IMethodSymbol method:
+                return $"return value of '{method.ToDisplayString(format)}'";
+            default:
+                return $"'{symbol.ToDisplayString(format)}'";
+        }
+    }
+
+    // Where the fix lands, relative to the diagnostic: ` (line 12)` when the declaration
+    // shares the diagnostic's file, ` (D:\src\Order.cs:12)` otherwise, nothing when it
+    // has no source location.
+    static string Site(Location diagnosticLocation, ISymbol? fixTarget)
+    {
+        var declaration = fixTarget.ResolveDeclarationLocation();
+        if (!declaration.IsInSource)
+        {
+            return "";
+        }
+
+        var span = declaration.GetMappedLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        if (declaration.SourceTree == diagnosticLocation.SourceTree ||
+            string.IsNullOrEmpty(span.Path))
+        {
+            return $" (line {line})";
+        }
+
+        return $" ({span.Path}:{line})";
+    }
+
+    static bool IsEditable(this ISymbol? symbol) =>
+        symbol.ResolveDeclarationLocation().IsInSource;
 
     static Location[]? GetAdditionalLocations(ISymbol? fixTarget)
     {


### PR DESCRIPTION
Every SIA message now names both declarations, spells out the attribute to write, and points at the declaration line (path when in another file). Descriptors carry a description and a helpLinkUri to docs/SIA00x.md, one page per rule with the message anatomy, fix options and suppressions. MessageTests pins the exact text of every rule.