### PR TITLE
fix SIA001/002/003 messages to render multi-tag sets as [UnionId(...)]

### DIFF
--- a/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
+++ b/src/StrongIdAnalyzer.Tests/IdMismatchAnalyzerTests.cs
@@ -2643,14 +2643,14 @@ public class IdMismatchAnalyzerTests
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         var message = diagnostics[0].GetMessage();
-        await Assert.That(message.Contains("TreasuryBid/BaseEntity")).IsTrue();
+        await Assert.That(message.Contains("""UnionId("TreasuryBid", "BaseEntity")""")).IsTrue();
     }
 
     [Test]
     public async Task Convention_InheritedId_DeepChain_MismatchMessage_MostDerivedFirst()
     {
-        // leaf.Id walks Leaf → Mid → Root. The resulting tag list must be
-        // "Leaf/Mid/Root" (most-derived first) so code fixes pick the receiver type.
+        // leaf.Id walks Leaf → Mid → Root. The resulting tag list must render
+        // most-derived first ("Leaf", "Mid", "Root") so code fixes pick the receiver type.
         var source =
             """
             using System;
@@ -2670,7 +2670,7 @@ public class IdMismatchAnalyzerTests
         var diagnostics = (await GetDiagnostics(source)).Where(_ => _.Id == "SIA001").ToArray();
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
-        await Assert.That(diagnostics[0].GetMessage().Contains("Leaf/Mid/Root")).IsTrue();
+        await Assert.That(diagnostics[0].GetMessage().Contains("""UnionId("Leaf", "Mid", "Root")""")).IsTrue();
     }
 
     [Test]

--- a/src/StrongIdAnalyzer.Tests/MessageTests.cs
+++ b/src/StrongIdAnalyzer.Tests/MessageTests.cs
@@ -105,7 +105,7 @@ public class MessageTests
         var diagnostic = await Single(source, "SIA002");
 
         await Assert.That(diagnostic.GetMessage()).IsEqualTo(
-            """property 'Sample.Raw' has no [Id] but flows to parameter 'key' of 'Sample.Lookup', which is [Id("Customer/Product")]. Fix: add [UnionId("Customer", "Product")] to property 'Sample.Raw' (line 4).""");
+            """property 'Sample.Raw' has no [Id] but flows to parameter 'key' of 'Sample.Lookup', which is [UnionId("Customer", "Product")]. Fix: add [UnionId("Customer", "Product")] to property 'Sample.Raw' (line 4).""");
     }
 
     [Test]

--- a/src/StrongIdAnalyzer/IdInfo.cs
+++ b/src/StrongIdAnalyzer/IdInfo.cs
@@ -62,9 +62,4 @@ readonly struct IdInfo
         }
         return false;
     }
-
-    // Flat representation for diagnostic messages. Multi-tag sets use "/" as a
-    // separator so a reader sees the full set at once: [Id("Child1/Base")].
-    public string Format() =>
-        Tags.IsDefaultOrEmpty ? "" : string.Join("/", Tags);
 }

--- a/src/StrongIdAnalyzer/Rules.cs
+++ b/src/StrongIdAnalyzer/Rules.cs
@@ -28,7 +28,7 @@ static class Rules
     static readonly DiagnosticDescriptor idMismatch = new(
         id: "SIA001",
         title: "Id type mismatch",
-        messageFormat: "{0} is [Id(\"{1}\")] and {2} {3}, which is [Id(\"{4}\")]. {5}.",
+        messageFormat: "{0} is {1} and {2} {3}, which is {4}. {5}.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -38,7 +38,7 @@ static class Rules
     static readonly DiagnosticDescriptor missingSourceId = new(
         id: "SIA002",
         title: "Source has no Id while target requires one",
-        messageFormat: "{0} has no [Id] but {1} {2}, which is [Id(\"{3}\")]. Fix: add {4} to {0}{5}.",
+        messageFormat: "{0} has no [Id] but {1} {2}, which is {3}. Fix: add {4} to {0}{5}.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -48,7 +48,7 @@ static class Rules
     static readonly DiagnosticDescriptor droppedId = new(
         id: "SIA003",
         title: "Source has Id while target has none",
-        messageFormat: "{0} is [Id(\"{1}\")] but {2} {3}, which has no [Id]. Fix: add {4} to {3}{5}.",
+        messageFormat: "{0} is {1} but {2} {3}, which has no [Id]. Fix: add {4} to {3}{5}.",
         category: "IdAttribute.Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -135,10 +135,10 @@ static class Rules
             messageArgs:
             [
                 Describe(sourceSymbol),
-                source.Format(),
+                FormatAttribute(source.Tags),
                 relation,
                 Describe(targetSymbol),
-                target.Format(),
+                FormatAttribute(target.Tags),
                 MismatchFix(location, sourceSymbol, sourceFixSite, source, targetSymbol, targetFixSite, target)
             ]));
 
@@ -285,7 +285,7 @@ static class Rules
             location,
             additionalLocations: GetAdditionalLocations(fixTarget),
             properties: ImmutableDictionary<string, string?>.Empty.Add(ValueKey, joined),
-            messageArgs: messageArgs(fixTags, info.Format()));
+            messageArgs: messageArgs(fixTags, FormatAttribute(info.Tags)));
     }
 
     // The attribute the reader should write: one tag → [Id("X")], several → the


### PR DESCRIPTION
Multi-tag sets (from UnionId or receiver-type inheritance walks) were joined with "/" and stuffed into a hardcoded [Id("...")] template, so a UnionId target read as one literal tag containing a slash instead of a set of accepted tags. Reuse FormatAttribute, already used by the Fix: clause, so the message body agrees with it.

Coded by Claude